### PR TITLE
fix: CORS에 Vercel 도메인 추가

### DIFF
--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/config/SecurityConfig.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/config/SecurityConfig.java
@@ -110,7 +110,9 @@ public class SecurityConfig {
         config.setAllowedOriginPatterns(List.of(
                 "http://localhost:*",
                 "http://127.0.0.1:*",
-                "http://56.228.20.104:*"
+                "http://56.228.20.104:*",
+                "https://guideon-frontend.vercel.app",
+                "https://*.vercel.app"
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
CORS에 Vercel 도메인이 없어서 추가 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **보안 설정 업데이트**
  * 백엔드 보안 설정이 업데이트되어 클라우드 배포 환경에서 프론트엔드 애플리케이션과 백엔드 서버 간의 안전한 통신을 지원합니다. CORS(교차 출처 리소스 공유) 허용 목록이 확장되었으며, 배포된 환경에서 서비스가 안정적으로 작동합니다. 기존의 모든 보안 설정은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->