### PR TITLE
fix: 이미지 캐시 정리 코드 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Copy deploy files to server
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@v0.1.9
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
@@ -82,5 +82,6 @@ jobs:
             docker compose pull
             docker compose up -d
             docker exec guideon-nginx nginx -s reload
+            docker image prune -af --filter "until=168h"
             echo "=== Deploy complete ==="
             docker compose ps


### PR DESCRIPTION
배포 오류가 나서 확인 했는데, 안쓰는 Docker 이미지/캐시 정리가 되어있지 않아 생긴 버그입니다.
ssh 서버 내에서 용량 확보 했고, 명령어 추가 해서 자동으로 이미지 정리 하도록 수정 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 배포 자동화 도구의 버전을 최신화하여 배포 프로세스의 안정성을 개선했습니다.
  * 배포 완료 후 서버의 168시간 이상 된 오래된 컨테이너 이미지를 자동으로 정리하는 기능을 추가하여 서버 저장소 용량을 효율적으로 관리할 수 있도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->