### PR TITLE
Feat/chat redis

### DIFF
--- a/guideon-core/src/main/java/com/guideon/core/api/ChatInternalController.java
+++ b/guideon-core/src/main/java/com/guideon/core/api/ChatInternalController.java
@@ -45,8 +45,11 @@ public class ChatInternalController {
      * 키오스크 종료 버튼 클릭 시 Kiosk BFF가 호출
      */
     @PostMapping("/sessions/{sessionId}/end")
-    public ResponseEntity<Void> endSession(@PathVariable String sessionId) {
-        chatService.endSession(sessionId);
+    public ResponseEntity<Void> endSession(
+            @PathVariable String sessionId,
+            @RequestParam String deviceId
+    ) {
+        chatService.endSession(sessionId, deviceId);
         return ResponseEntity.ok().build();
     }
 }

--- a/guideon-core/src/main/java/com/guideon/core/api/ChatInternalController.java
+++ b/guideon-core/src/main/java/com/guideon/core/api/ChatInternalController.java
@@ -38,4 +38,15 @@ public class ChatInternalController {
         ChatResult result = chatService.sendMessage(command);
         return ResponseEntity.ok(result);
     }
+
+    /**
+     * POST /internal/v1/chat/sessions/{sessionId}/end
+     * 세션 종료 — DB ended_at 기록 + Redis 대화 내역 삭제
+     * 키오스크 종료 버튼 클릭 시 Kiosk BFF가 호출
+     */
+    @PostMapping("/sessions/{sessionId}/end")
+    public ResponseEntity<Void> endSession(@PathVariable String sessionId) {
+        chatService.endSession(sessionId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatHistoryService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatHistoryService.java
@@ -37,6 +37,12 @@ public class ChatHistoryService {
     public void saveTurn(String sessionId, String question, String answer) {
         String key = KEY_PREFIX + sessionId;
 
+        // Map.of()는 null 값 허용 안 함 — 먼저 방어
+        if (question == null || answer == null) {
+            log.warn("[ChatHistory] 저장 생략: sessionId={}, null message payload", sessionId);
+            return;
+        }
+
         // JSON 직렬화 — 실패 시 Redis 저장 생략
         final String userMsg;
         final String assistantMsg;
@@ -64,8 +70,14 @@ public class ChatHistoryService {
 
     /**
      * 세션 종료 시 대화 내역 삭제
+     * afterCommit() 콜백에서 호출되므로 예외가 전파되면 DB 커밋 성공 후에도 실패처럼 보임.
+     * 예외를 흡수하고 경고 로그만 남긴다.
      */
     public void deleteHistory(String sessionId) {
-        redisTemplate.delete(KEY_PREFIX + sessionId);
+        try {
+            redisTemplate.delete(KEY_PREFIX + sessionId);
+        } catch (Exception e) {
+            log.warn("[ChatHistory] Redis 삭제 실패: sessionId={}, {}", sessionId, e.getMessage());
+        }
     }
 }

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatHistoryService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatHistoryService.java
@@ -1,0 +1,55 @@
+package com.guideon.core.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * 대화 내역 Redis 관리 서비스
+ *
+ * 키: chat:{sessionId}
+ * 값: JSON 직렬화된 메시지 리스트 (role/content)
+ * TTL: 30분 (세션 활동 시마다 갱신, 키오스크 종료 시 즉시 삭제)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatHistoryService {
+
+    private static final String KEY_PREFIX = "chat:";
+    private static final Duration TTL = Duration.ofMinutes(30);
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 대화 1턴(질문 + 답변) 저장
+     */
+    public void saveTurn(String sessionId, String question, String answer) {
+        String key = KEY_PREFIX + sessionId;
+        try {
+            String userMsg = objectMapper.writeValueAsString(Map.of("role", "user", "content", question));
+            String assistantMsg = objectMapper.writeValueAsString(Map.of("role", "assistant", "content", answer));
+
+            redisTemplate.opsForList().rightPush(key, Objects.requireNonNull(userMsg));
+            redisTemplate.opsForList().rightPush(key, Objects.requireNonNull(assistantMsg));
+            redisTemplate.expire(key, Objects.requireNonNull(TTL));
+        } catch (JsonProcessingException e) {
+            log.warn("[ChatHistory] 저장 실패: sessionId={}, {}", sessionId, e.getMessage());
+        }
+    }
+
+    /**
+     * 세션 종료 시 대화 내역 삭제
+     */
+    public void deleteHistory(String sessionId) {
+        redisTemplate.delete(KEY_PREFIX + sessionId);
+    }
+}

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatHistoryService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatHistoryService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * 대화 내역 Redis 관리 서비스
@@ -31,18 +30,35 @@ public class ChatHistoryService {
 
     /**
      * 대화 1턴(질문 + 답변) 저장
+     * - JSON 직렬화 실패 시 Redis 저장 생략 (chat 흐름은 유지)
+     * - Redis 연결 오류 등 런타임 예외는 별도 catch로 처리
+     * - TTL 적용 실패 시 경고 로그 (키가 이미 삭제된 경우 등)
      */
     public void saveTurn(String sessionId, String question, String answer) {
         String key = KEY_PREFIX + sessionId;
-        try {
-            String userMsg = objectMapper.writeValueAsString(Map.of("role", "user", "content", question));
-            String assistantMsg = objectMapper.writeValueAsString(Map.of("role", "assistant", "content", answer));
 
-            redisTemplate.opsForList().rightPush(key, Objects.requireNonNull(userMsg));
-            redisTemplate.opsForList().rightPush(key, Objects.requireNonNull(assistantMsg));
-            redisTemplate.expire(key, Objects.requireNonNull(TTL));
+        // JSON 직렬화 — 실패 시 Redis 저장 생략
+        final String userMsg;
+        final String assistantMsg;
+        try {
+            userMsg = objectMapper.writeValueAsString(Map.of("role", "user", "content", question));
+            assistantMsg = objectMapper.writeValueAsString(Map.of("role", "assistant", "content", answer));
         } catch (JsonProcessingException e) {
-            log.warn("[ChatHistory] 저장 실패: sessionId={}, {}", sessionId, e.getMessage());
+            log.warn("[ChatHistory] JSON 직렬화 실패: sessionId={}, {}", sessionId, e.getMessage());
+            return;
+        }
+
+        // Redis 저장 — 연결 오류 등 런타임 예외 처리
+        try {
+            // rightPushAll로 두 메시지를 한 번에 저장 (네트워크 왕복 1회 절감)
+            redisTemplate.opsForList().rightPushAll(key, userMsg, assistantMsg);
+
+            Boolean ttlApplied = redisTemplate.expire(key, TTL);
+            if (!Boolean.TRUE.equals(ttlApplied)) {
+                log.warn("[ChatHistory] TTL 적용 실패 (키 없음?): sessionId={}", sessionId);
+            }
+        } catch (Exception e) {
+            log.warn("[ChatHistory] Redis 저장 실패: sessionId={}, {}", sessionId, e.getMessage());
         }
     }
 

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
@@ -23,6 +23,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -54,6 +56,9 @@ public class ChatService {
     /**
      * 세션 종료 — DB ended_at 기록 + Redis 대화 내역 삭제
      * 키오스크 종료 버튼 클릭 시 호출
+     *
+     * Redis 삭제는 트랜잭션 커밋 이후 afterCommit() 콜백에서 실행.
+     * DB 롤백 시 Redis 삭제가 불필요하게 일어나는 것을 방지.
      */
     @Transactional
     public void endSession(String sessionId) {
@@ -61,7 +66,14 @@ public class ChatService {
             session.endSession();
             log.info("Chat 세션 종료: sessionId={}", sessionId);
         });
-        chatHistoryService.deleteHistory(sessionId);
+
+        // DB 커밋 완료 후 Redis 삭제 (트랜잭션 롤백 시 Redis 삭제 방지)
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                chatHistoryService.deleteHistory(sessionId);
+            }
+        });
     }
 
     /**

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
@@ -61,8 +61,18 @@ public class ChatService {
      * DB 롤백 시 Redis 삭제가 불필요하게 일어나는 것을 방지.
      */
     @Transactional
-    public void endSession(String sessionId) {
+    public void endSession(String sessionId, String deviceId) {
         chatSessionRepository.findById(sessionId).ifPresent(session -> {
+            // 호출자(deviceId)와 세션 소유자 일치 여부 검증
+            if (!session.getDeviceId().equals(deviceId)) {
+                log.warn("세션 소유권 불일치: sessionId={}, 요청 deviceId=***", sessionId);
+                throw new SecurityException("세션 소유권이 없습니다: " + sessionId);
+            }
+            // 이미 종료된 세션 재요청은 무시 (endedAt 덮어쓰기 방지)
+            if (session.getEndedAt() != null) {
+                log.info("이미 종료된 Chat 세션 재요청 무시: sessionId={}", sessionId);
+                return;
+            }
             session.endSession();
             log.info("Chat 세션 종료: sessionId={}", sessionId);
         });

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
@@ -49,6 +49,20 @@ public class ChatService {
     private final PlaceRepository placeRepository;
     private final DeviceRepository deviceRepository;
     private final MascotRepository mascotRepository;
+    private final ChatHistoryService chatHistoryService;
+
+    /**
+     * 세션 종료 — DB ended_at 기록 + Redis 대화 내역 삭제
+     * 키오스크 종료 버튼 클릭 시 호출
+     */
+    @Transactional
+    public void endSession(String sessionId) {
+        chatSessionRepository.findById(sessionId).ifPresent(session -> {
+            session.endSession();
+            log.info("Chat 세션 종료: sessionId={}", sessionId);
+        });
+        chatHistoryService.deleteHistory(sessionId);
+    }
 
     /**
      * 대화 세션 생성 — UUID 생성 + DB 저장
@@ -132,7 +146,10 @@ public class ChatService {
 
         chatMessageRepository.save(chatMessage);
 
-        // 8. Display hint 조립
+        // 8. 대화 내역 Redis 저장
+        chatHistoryService.saveTurn(command.getSessionId(), command.getMessage(), qaResponse.getAnswer());
+
+        // 9. Display hint 조립
         return buildChatResult(command.getSessionId(), command, qaResponse);
     }
 

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
@@ -103,12 +103,19 @@ public class ChatService {
     public ChatResult sendMessage(ChatCommand command) {
         long startTime = System.currentTimeMillis();
 
-        // 1. 세션 조회 + 메시지 카운트 증가
+        // 1. 세션 조회 + 종료 여부 확인 + 메시지 카운트 증가
         ChatSession session = chatSessionRepository.findById(command.getSessionId())
                 .orElseThrow(() -> {
                     log.warn("세션 없음: sessionId={}", command.getSessionId());
                     return new IllegalArgumentException("유효하지 않은 세션입니다: " + command.getSessionId());
                 });
+
+        // 이미 종료된 세션으로 메시지가 들어오면 거부 (endedAt 기록 후 Redis 재생성 방지)
+        if (session.getEndedAt() != null) {
+            log.warn("종료된 세션으로 메시지 수신: sessionId={}", command.getSessionId());
+            throw new IllegalStateException("이미 종료된 세션입니다: " + command.getSessionId());
+        }
+
         session.incrementMessageCount();
 
         // 2. 마스코트 systemPrompt + promptConfig 조회
@@ -158,8 +165,15 @@ public class ChatService {
 
         chatMessageRepository.save(chatMessage);
 
-        // 8. 대화 내역 Redis 저장
-        chatHistoryService.saveTurn(command.getSessionId(), command.getMessage(), qaResponse.getAnswer());
+        // 8. DB 커밋 후 Redis 저장 (커밋 실패 시 Redis에만 데이터 남는 불일치 방지)
+        final String question = command.getMessage();
+        final String answer = qaResponse.getAnswer();
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                chatHistoryService.saveTurn(command.getSessionId(), question, answer);
+            }
+        });
 
         // 9. Display hint 조립
         return buildChatResult(command.getSessionId(), command, qaResponse);

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/client/CoreChatClient.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/client/CoreChatClient.java
@@ -27,5 +27,8 @@ public interface CoreChatClient {
      * 키오스크 종료 버튼 클릭 시 호출
      */
     @PostMapping("/internal/v1/chat/sessions/{sessionId}/end")
-    void endSession(@PathVariable String sessionId);
+    void endSession(
+            @PathVariable String sessionId,
+            @RequestParam String deviceId
+    );
 }

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/client/CoreChatClient.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/client/CoreChatClient.java
@@ -21,4 +21,11 @@ public interface CoreChatClient {
             @PathVariable String sessionId,
             @RequestBody ChatCommand command
     );
+
+    /**
+     * 세션 종료 — DB ended_at 기록 + Redis 대화 내역 삭제
+     * 키오스크 종료 버튼 클릭 시 호출
+     */
+    @PostMapping("/internal/v1/chat/sessions/{sessionId}/end")
+    void endSession(@PathVariable String sessionId);
 }

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/controller/KioskChatController.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/controller/KioskChatController.java
@@ -42,10 +42,11 @@ public class KioskChatController {
     @DeleteMapping("/sessions/{sessionId}")
     public ResponseEntity<ApiResponse<Void>> endSession(
             @PathVariable String sessionId,
+            @AuthenticationPrincipal DeviceDetails device,
             HttpServletRequest httpRequest
     ) {
         String traceId = (String) httpRequest.getAttribute(TraceIdUtil.TRACE_ID_ATTR);
-        chatService.endSession(sessionId);
+        chatService.endSession(sessionId, device.getDeviceId());
         return ResponseEntity.ok(ApiResponse.success(null, traceId));
     }
 

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/controller/KioskChatController.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/controller/KioskChatController.java
@@ -35,6 +35,21 @@ public class KioskChatController {
     }
 
     /**
+     * DELETE /kiosk/chat/sessions/{sessionId}
+     * 세션 종료 — DB ended_at 기록 + Redis 대화 내역 즉시 삭제
+     * 키오스크 종료 버튼 클릭 시 호출
+     */
+    @DeleteMapping("/sessions/{sessionId}")
+    public ResponseEntity<ApiResponse<Void>> endSession(
+            @PathVariable String sessionId,
+            HttpServletRequest httpRequest
+    ) {
+        String traceId = (String) httpRequest.getAttribute(TraceIdUtil.TRACE_ID_ATTR);
+        chatService.endSession(sessionId);
+        return ResponseEntity.ok(ApiResponse.success(null, traceId));
+    }
+
+    /**
      * POST /kiosk/chat/sessions/{sessionId}/messages
      * 대화 메시지 전송 → AI 응답 + display hint 반환
      */

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/service/ChatService.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/service/ChatService.java
@@ -43,6 +43,20 @@ public class ChatService {
     }
 
     /**
+     * 세션 종료 — Core에 위임 (DB ended_at 기록 + Redis 대화 내역 삭제)
+     * 키오스크 종료 버튼 클릭 시 호출
+     */
+    public void endSession(String sessionId) {
+        try {
+            coreChatClient.endSession(sessionId);
+            log.info("Chat 세션 종료 요청: sessionId={}", sessionId);
+        } catch (Exception e) {
+            log.error("세션 종료 실패: sessionId={}, {}", sessionId, e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
      * 메시지 처리 — Core에 위임 + 응답 변환
      */
     public ChatMessageResponse sendMessage(

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/service/ChatService.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/service/ChatService.java
@@ -46,9 +46,9 @@ public class ChatService {
      * 세션 종료 — Core에 위임 (DB ended_at 기록 + Redis 대화 내역 삭제)
      * 키오스크 종료 버튼 클릭 시 호출
      */
-    public void endSession(String sessionId) {
+    public void endSession(String sessionId, String deviceId) {
         try {
-            coreChatClient.endSession(sessionId);
+            coreChatClient.endSession(sessionId, deviceId);
             log.info("Chat 세션 종료 요청: sessionId={}", sessionId);
         } catch (Exception e) {
             log.error("세션 종료 실패: sessionId={}, {}", sessionId, e.getMessage());


### PR DESCRIPTION
## Summary
- #122 
-

## Tasks
- [x] 채팅 내용 Redis에 저장
- [x] 세션 종료 시 자동 삭제
- [x] 비정상 종료 시 30분 후 자동삭제 
## To Reviewer
- 

## Screenshot
<img src="" width="50%" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅 세션을 명시적으로 종료하는 API 및 UI 엔드포인트 추가
  * 세션 종료 시 서버에서 해당 세션의 대화 기록을 삭제하도록 자동 정리 동작 추가

* **동작 변경 / 개선**
  * 대화 내용이 세션별로 자동 저장되어 이전 메시지 참조 가능(보관기간 약 30분)
  * 종료된 세션에는 메시지 전송이 차단됨; 대화 저장·삭제는 데이터베이스 커밋 후에 반영되어 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->