### PR TITLE
Feat/tts websocket

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       CORE_SERVICE_URL: http://core:8080
-      FASTAPI_SERVICE_URL: ${FASTAPI_SERVICE_URL:-http://localhost:8000}
+      FASTAPI_SERVICE_URL: ${FASTAPI_SERVICE_URL:-http://host.docker.internal:8000}
     depends_on:
       - core
     networks:

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
@@ -1,0 +1,139 @@
+package com.guideon.kiosk.domain.stt.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okio.ByteString;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+/**
+ * FastAPI /ws/stream WebSocket 연결 관리
+ *
+ * Unity ↔ BFF ↔ FastAPI 릴레이:
+ * - Unity → (binary PCM chunk) → BFF → FastAPI
+ * - Unity → (text: {"type":"stop"}) → BFF → FastAPI
+ * - FastAPI → (text: stt_interim/stt_final/tts_chunk/final_text/done/error) → BFF → Unity
+ *
+ * FastAPI 프로토콜:
+ * 1. 연결 후 {"type":"start", "site_id":1, "language_code":"ko-KR", ...} 전송
+ * 2. binary PCM 청크 스트리밍
+ * 3. {"type":"stop"} 전송 → FastAPI가 STT 종료 후 QA → TTS 처리
+ * 4. FastAPI가 {"type":"done"} 전송하면 파이프라인 완료
+ */
+@Slf4j
+public class FastApiStreamSession {
+
+    private final WebSocketSession unitySession;
+    private final String sessionId;
+    private volatile WebSocket fastapiWs;
+    private volatile boolean closed = false;
+
+    /**
+     * @param okHttpClient   FastApiConfig에서 주입받은 OkHttpClient
+     * @param wsUrl          ws://host:port/ws/stream
+     * @param unitySession   Unity ↔ BFF Spring WebSocket 세션
+     * @param sessionId      채팅 sessionId (로깅용)
+     * @param startPayload   FastAPI에 최초 전송할 JSON {"type":"start", ...}
+     */
+    public FastApiStreamSession(
+            OkHttpClient okHttpClient,
+            String wsUrl,
+            WebSocketSession unitySession,
+            String sessionId,
+            String startPayload
+    ) {
+        this.unitySession = unitySession;
+        this.sessionId = sessionId;
+
+        Request request = new Request.Builder().url(wsUrl).build();
+        fastapiWs = okHttpClient.newWebSocket(request, new FastApiListener(startPayload));
+        log.info("[FastApiStream] FastAPI WS 연결 시도: sessionId={}, url={}", sessionId, wsUrl);
+    }
+
+    /** Unity에서 수신한 PCM 오디오 청크를 FastAPI로 중계 */
+    public void relayBinary(byte[] data) {
+        if (!closed && fastapiWs != null) {
+            fastapiWs.send(ByteString.of(data));
+        }
+    }
+
+    /** Unity에서 수신한 텍스트 제어 메시지(예: {"type":"stop"})를 FastAPI로 중계 */
+    public void relayText(String text) {
+        if (!closed && fastapiWs != null) {
+            fastapiWs.send(text);
+        }
+    }
+
+    /** Unity 연결 종료 시 FastAPI WS도 닫음 */
+    public void close() {
+        if (!closed) {
+            closed = true;
+            if (fastapiWs != null) {
+                fastapiWs.close(1000, "Unity disconnected");
+                log.info("[FastApiStream] FastAPI WS 정상 종료: sessionId={}", sessionId);
+            }
+        }
+    }
+
+    /** FastAPI WebSocket 이벤트 처리 */
+    private class FastApiListener extends WebSocketListener {
+
+        private final String startPayload;
+
+        FastApiListener(String startPayload) {
+            this.startPayload = startPayload;
+        }
+
+        @Override
+        public void onOpen(WebSocket webSocket, Response response) {
+            log.info("[FastApiStream] FastAPI WS 연결 성공: sessionId={}", sessionId);
+            webSocket.send(startPayload);
+        }
+
+        /** FastAPI → BFF 텍스트 메시지: STT 결과, TTS 청크, 상태 등 → Unity로 그대로 중계 */
+        @Override
+        public void onMessage(WebSocket webSocket, String text) {
+            if (text == null) return;
+            try {
+                if (unitySession.isOpen()) {
+                    unitySession.sendMessage(new TextMessage(text));
+                }
+            } catch (IOException e) {
+                log.error("[FastApiStream] Unity 전송 실패: sessionId={}, error={}", sessionId, e.getMessage());
+            }
+        }
+
+        @Override
+        public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+            log.error("[FastApiStream] FastAPI WS 오류: sessionId={}, error={}", sessionId, t.getMessage());
+            closed = true;
+            sendErrorToUnity("FASTAPI_UNAVAILABLE", "FastAPI 연결 오류: " + t.getMessage());
+        }
+
+        @Override
+        public void onClosed(WebSocket webSocket, int code, String reason) {
+            log.info("[FastApiStream] FastAPI WS 종료: sessionId={}, code={}, reason={}", sessionId, code, reason);
+        }
+
+        private void sendErrorToUnity(String code, String message) {
+            try {
+                if (unitySession.isOpen()) {
+                    String safeMsg = message != null ? message.replace("\"", "'") : "";
+                    String errorJson = String.format(
+                            "{\"type\":\"error\",\"code\":\"%s\",\"message\":\"%s\"}",
+                            code, safeMsg
+                    );
+                    unitySession.sendMessage(new TextMessage(errorJson));
+                }
+            } catch (IOException e) {
+                log.debug("[FastApiStream] Unity 오류 메시지 전송 실패: sessionId={}, {}", sessionId, e.getMessage());
+            }
+        }
+    }
+}

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
@@ -124,16 +124,24 @@ public class FastApiStreamSession {
         private void sendErrorToUnity(String code, String message) {
             try {
                 if (unitySession.isOpen()) {
-                    String safeMsg = message != null ? message.replace("\"", "'") : "";
                     String errorJson = String.format(
                             "{\"type\":\"error\",\"code\":\"%s\",\"message\":\"%s\"}",
-                            code, safeMsg
+                            code, escapeJson(message)
                     );
                     unitySession.sendMessage(new TextMessage(errorJson));
                 }
             } catch (IOException e) {
                 log.debug("[FastApiStream] Unity 오류 메시지 전송 실패: sessionId={}, {}", sessionId, e.getMessage());
             }
+        }
+
+        private String escapeJson(String str) {
+            if (str == null) return "";
+            return str.replace("\\", "\\\\")
+                      .replace("\"", "\\\"")
+                      .replace("\n", "\\n")
+                      .replace("\r", "\\r")
+                      .replace("\t", "\\t");
         }
     }
 }

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
@@ -68,14 +68,20 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         DeviceDetails device = getDeviceDetails(session);
-        String sessionId = getSessionId(session);
+        Map<String, String> params = parseQueryParams(session);
+        String sessionId = params.get("sessionId");
+        if (sessionId == null || sessionId.isBlank()) {
+            log.warn("STT WS 연결 거부: sessionId 누락");
+            session.close(CloseStatus.BAD_DATA.withReason("sessionId is required"));
+            return;
+        }
+
         log.info("STT WS 연결: deviceId={}, sessionId={}",
                 device != null ? device.getDeviceId() : "unknown", sessionId);
 
-        Map<String, String> params = parseQueryParams(session);
-        int siteId = parseIntOrDefault(params.get("siteId"), 1);
+        int siteId = parsePositiveIntOrDefault(params.get("siteId"), 1);
         String languageCode = params.getOrDefault("languageCode", "ko-KR");
-        int sampleRate = parseIntOrDefault(params.get("sampleRate"), 16000);
+        int sampleRate = parsePositiveIntOrDefault(params.get("sampleRate"), 16000);
         boolean ttsStream = !"false".equalsIgnoreCase(params.get("ttsStream"));
 
         String startPayload = buildStartPayload(siteId, languageCode, sampleRate, ttsStream);
@@ -169,28 +175,16 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         return params;
     }
 
-    private String getSessionId(WebSocketSession session) {
-        String query = session.getUri() != null ? session.getUri().getRawQuery() : null;
-        if (query != null) {
-            for (String param : query.split("&")) {
-                String[] kv = param.split("=", 2);
-                if ("sessionId".equals(kv[0]) && kv.length == 2) {
-                    return URLDecoder.decode(kv[1], StandardCharsets.UTF_8);
-                }
-            }
-        }
-        return session.getId();
-    }
-
     private DeviceDetails getDeviceDetails(WebSocketSession session) {
         return (DeviceDetails) session.getAttributes()
                 .get(DeviceTokenHandshakeInterceptor.DEVICE_DETAILS_ATTR);
     }
 
-    private int parseIntOrDefault(String value, int defaultValue) {
+    private int parsePositiveIntOrDefault(String value, int defaultValue) {
         if (value == null) return defaultValue;
         try {
-            return Integer.parseInt(value);
+            int parsed = Integer.parseInt(value);
+            return parsed > 0 ? parsed : defaultValue;
         } catch (NumberFormatException e) {
             return defaultValue;
         }

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
@@ -1,63 +1,103 @@
 package com.guideon.kiosk.domain.stt.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.guideon.kiosk.domain.stt.dto.SttResultMessage;
+import com.guideon.kiosk.global.config.FastApiConfig;
 import com.guideon.kiosk.global.security.DeviceDetails;
 import com.guideon.kiosk.global.security.DeviceTokenHandshakeInterceptor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.BinaryMessage;
-import org.springframework.web.socket.CloseStatus;
-import org.springframework.web.socket.TextMessage;
-import org.springframework.web.socket.WebSocketSession;
-import org.springframework.web.socket.handler.BinaryWebSocketHandler;
+import org.springframework.web.socket.*;
+import org.springframework.web.socket.handler.AbstractWebSocketHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * STT WebSocket Handler
  *
- * Unity → (binary audio chunk) → Kiosk BFF → FastAPI STT → (text JSON) → Unity
+ * Unity → (binary PCM) / (text control) → BFF → FastAPI /ws/stream
+ *                                                         ↓
+ * Unity ← (stt_interim/stt_final/tts_chunk/final_text/done) ← BFF ← FastAPI
  *
- * 프로토콜:
- * - Client → Server: binary audio chunk (PCM/OGG)
- * - Server → Client: JSON { type: "partial"|"final", transcript, confidence, sessionId }
+ * 프로토콜 (Unity → BFF):
+ * - binary frame: PCM 오디오 청크
+ * - text frame:   {"type":"stop"} — 오디오 스트림 종료 신호
  *
- * FastAPI 미구현 시 stub 응답 반환.
+ * 프로토콜 (BFF → Unity, FastAPI 메시지 그대로 중계):
+ * - {"type":"status",  "stage":"stt_start"|"stt_done"|"tts_start"|...}
+ * - {"type":"stt_interim", "text":"...", "language_code":"...", "confidence":0.9}
+ * - {"type":"stt_final",   "text":"...", "language_code":"...", "confidence":0.9}
+ * - {"type":"tts_chunk",   "seq":0, "text":"...", "audio_b64":"...", "is_final":true}
+ * - {"type":"final_text",  "query":"...", "answer":"..."}
+ * - {"type":"done"}
+ * - {"type":"error",   "code":"...", "message":"..."}
+ *
+ * WS 쿼리 파라미터 (Unity → BFF):
+ * - sessionId:    채팅 세션 ID (필수)
+ * - siteId:       사이트 ID (기본값 1)
+ * - languageCode: 언어 코드 (기본값 ko-KR)
+ * - sampleRate:   PCM 샘플레이트 Hz (기본값 16000)
+ * - ttsStream:    TTS 스트리밍 여부 (기본값 true)
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class SttWebSocketHandler extends BinaryWebSocketHandler {
+public class SttWebSocketHandler extends AbstractWebSocketHandler {
 
     private final ObjectMapper objectMapper;
+    private final FastApiConfig fastApiConfig;
+
+    // qualifier로 Feign용 OkHttpClient와 분리
+    @Qualifier("fastapiOkHttpClient")
+    private final OkHttpClient okHttpClient;
+
+    /** Spring WS session.getId() → FastApiStreamSession */
+    private final ConcurrentHashMap<String, FastApiStreamSession> sessions = new ConcurrentHashMap<>();
 
     @Override
-    public void afterConnectionEstablished(WebSocketSession session) {
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         DeviceDetails device = getDeviceDetails(session);
         String sessionId = getSessionId(session);
         log.info("STT WS 연결: deviceId={}, sessionId={}", device.getDeviceId(), sessionId);
+
+        Map<String, String> params = parseQueryParams(session);
+        int siteId = parseIntOrDefault(params.get("siteId"), 1);
+        String languageCode = params.getOrDefault("languageCode", "ko-KR");
+        int sampleRate = parseIntOrDefault(params.get("sampleRate"), 16000);
+        boolean ttsStream = !"false".equalsIgnoreCase(params.get("ttsStream"));
+
+        String startPayload = buildStartPayload(siteId, languageCode, sampleRate, ttsStream);
+
+        FastApiStreamSession fastApiSession = new FastApiStreamSession(
+                okHttpClient,
+                fastApiConfig.getWsStreamUrl(),
+                session,
+                sessionId,
+                startPayload
+        );
+        sessions.put(session.getId(), fastApiSession);
     }
 
+    /** Unity → binary PCM → FastAPI */
     @Override
-    protected void handleBinaryMessage(WebSocketSession session, BinaryMessage message) throws Exception {
-        DeviceDetails device = getDeviceDetails(session);
-        String sessionId = getSessionId(session);
-        int audioSize = message.getPayloadLength();
+    protected void handleBinaryMessage(WebSocketSession session, BinaryMessage message) {
+        FastApiStreamSession fastApiSession = sessions.get(session.getId());
+        if (fastApiSession != null) {
+            fastApiSession.relayBinary(message.getPayload().array());
+        }
+    }
 
-        log.debug("STT 오디오 수신: deviceId={}, sessionId={}, size={}bytes",
-                device.getDeviceId(), sessionId, audioSize);
-
-        // TODO: FastAPI WS/REST로 오디오 전달 후 결과 수신
-        // 현재는 stub 응답 반환
-        SttResultMessage stubResult = SttResultMessage.builder()
-                .type("final")
-                .transcript("[STT 서비스 연결 대기 중]")
-                .confidence(0.0)
-                .sessionId(sessionId)
-                .build();
-
-        String json = objectMapper.writeValueAsString(stubResult);
-        session.sendMessage(new TextMessage(json));
+    /** Unity → text({"type":"stop"}) → FastAPI */
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) {
+        FastApiStreamSession fastApiSession = sessions.get(session.getId());
+        if (fastApiSession != null) {
+            fastApiSession.relayText(message.getPayload());
+        }
     }
 
     @Override
@@ -72,11 +112,48 @@ public class SttWebSocketHandler extends BinaryWebSocketHandler {
         DeviceDetails device = getDeviceDetails(session);
         log.info("STT WS 종료: deviceId={}, status={}",
                 device != null ? device.getDeviceId() : "unknown", status);
+
+        FastApiStreamSession fastApiSession = sessions.remove(session.getId());
+        if (fastApiSession != null) {
+            fastApiSession.close();
+        }
     }
 
-    private DeviceDetails getDeviceDetails(WebSocketSession session) {
-        return (DeviceDetails) session.getAttributes()
-                .get(DeviceTokenHandshakeInterceptor.DEVICE_DETAILS_ATTR);
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private String buildStartPayload(int siteId, String languageCode, int sampleRate, boolean ttsStream) {
+        try {
+            Map<String, Object> start = new HashMap<>();
+            start.put("type", "start");
+            start.put("site_id", siteId);
+            start.put("language_code", languageCode);
+            start.put("sample_rate_hz", sampleRate);
+            start.put("interim_results", true);
+            start.put("tts_stream", ttsStream);
+            start.put("realtime", true);
+            return objectMapper.writeValueAsString(start);
+        } catch (Exception e) {
+            // fallback: 수동 조립
+            return String.format(
+                    "{\"type\":\"start\",\"site_id\":%d,\"language_code\":\"%s\","
+                            + "\"sample_rate_hz\":%d,\"interim_results\":true,"
+                            + "\"tts_stream\":%b,\"realtime\":true}",
+                    siteId, languageCode, sampleRate, ttsStream
+            );
+        }
+    }
+
+    private Map<String, String> parseQueryParams(WebSocketSession session) {
+        Map<String, String> params = new HashMap<>();
+        String query = session.getUri() != null ? session.getUri().getQuery() : null;
+        if (query == null) return params;
+        for (String pair : query.split("&")) {
+            String[] kv = pair.split("=", 2);
+            if (kv.length == 2) {
+                params.put(kv[0], kv[1]);
+            }
+        }
+        return params;
     }
 
     private String getSessionId(WebSocketSession session) {
@@ -90,5 +167,19 @@ public class SttWebSocketHandler extends BinaryWebSocketHandler {
             }
         }
         return session.getId();
+    }
+
+    private DeviceDetails getDeviceDetails(WebSocketSession session) {
+        return (DeviceDetails) session.getAttributes()
+                .get(DeviceTokenHandshakeInterceptor.DEVICE_DETAILS_ATTR);
+    }
+
+    private int parseIntOrDefault(String value, int defaultValue) {
+        if (value == null) return defaultValue;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
     }
 }

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
@@ -69,7 +69,8 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         DeviceDetails device = getDeviceDetails(session);
         String sessionId = getSessionId(session);
-        log.info("STT WS 연결: deviceId={}, sessionId={}", device.getDeviceId(), sessionId);
+        log.info("STT WS 연결: deviceId={}, sessionId={}",
+                device != null ? device.getDeviceId() : "unknown", sessionId);
 
         Map<String, String> params = parseQueryParams(session);
         int siteId = parseIntOrDefault(params.get("siteId"), 1);
@@ -94,7 +95,10 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     protected void handleBinaryMessage(WebSocketSession session, BinaryMessage message) {
         FastApiStreamSession fastApiSession = sessions.get(session.getId());
         if (fastApiSession != null) {
-            fastApiSession.relayBinary(message.getPayload().array());
+            java.nio.ByteBuffer payload = message.getPayload().asReadOnlyBuffer();
+            byte[] bytes = new byte[payload.remaining()];
+            payload.get(bytes);
+            fastApiSession.relayBinary(bytes);
         }
     }
 
@@ -151,7 +155,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
 
     private Map<String, String> parseQueryParams(WebSocketSession session) {
         Map<String, String> params = new HashMap<>();
-        String query = session.getUri() != null ? session.getUri().getQuery() : null;
+        String query = session.getUri() != null ? session.getUri().getRawQuery() : null;
         if (query == null) return params;
         for (String pair : query.split("&")) {
             String[] kv = pair.split("=", 2);
@@ -166,7 +170,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     }
 
     private String getSessionId(WebSocketSession session) {
-        String query = session.getUri() != null ? session.getUri().getQuery() : null;
+        String query = session.getUri() != null ? session.getUri().getRawQuery() : null;
         if (query != null) {
             for (String param : query.split("&")) {
                 String[] kv = param.split("=", 2);

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.guideon.kiosk.global.config.FastApiConfig;
 import com.guideon.kiosk.global.security.DeviceDetails;
 import com.guideon.kiosk.global.security.DeviceTokenHandshakeInterceptor;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -12,6 +11,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.*;
 import org.springframework.web.socket.handler.AbstractWebSocketHandler;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -45,18 +46,24 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class SttWebSocketHandler extends AbstractWebSocketHandler {
 
     private final ObjectMapper objectMapper;
     private final FastApiConfig fastApiConfig;
-
-    // qualifier로 Feign용 OkHttpClient와 분리
-    @Qualifier("fastapiOkHttpClient")
     private final OkHttpClient okHttpClient;
 
     /** Spring WS session.getId() → FastApiStreamSession */
     private final ConcurrentHashMap<String, FastApiStreamSession> sessions = new ConcurrentHashMap<>();
+
+    public SttWebSocketHandler(
+            ObjectMapper objectMapper,
+            FastApiConfig fastApiConfig,
+            @Qualifier("fastapiOkHttpClient") OkHttpClient okHttpClient
+    ) {
+        this.objectMapper = objectMapper;
+        this.fastApiConfig = fastApiConfig;
+        this.okHttpClient = okHttpClient;
+    }
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
@@ -133,7 +140,6 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
             start.put("realtime", true);
             return objectMapper.writeValueAsString(start);
         } catch (Exception e) {
-            // fallback: 수동 조립
             return String.format(
                     "{\"type\":\"start\",\"site_id\":%d,\"language_code\":\"%s\","
                             + "\"sample_rate_hz\":%d,\"interim_results\":true,"
@@ -150,7 +156,10 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         for (String pair : query.split("&")) {
             String[] kv = pair.split("=", 2);
             if (kv.length == 2) {
-                params.put(kv[0], kv[1]);
+                params.put(
+                        URLDecoder.decode(kv[0], StandardCharsets.UTF_8),
+                        URLDecoder.decode(kv[1], StandardCharsets.UTF_8)
+                );
             }
         }
         return params;
@@ -162,7 +171,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
             for (String param : query.split("&")) {
                 String[] kv = param.split("=", 2);
                 if ("sessionId".equals(kv[0]) && kv.length == 2) {
-                    return kv[1];
+                    return URLDecoder.decode(kv[1], StandardCharsets.UTF_8);
                 }
             }
         }

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/global/config/FastApiConfig.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/global/config/FastApiConfig.java
@@ -1,0 +1,43 @@
+package com.guideon.kiosk.global.config;
+
+import okhttp3.OkHttpClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * FastAPI 연동 설정
+ *
+ * - OkHttpClient Bean: WebSocket 연결용 (read timeout 0 = 무제한, WS keepalive에 필요)
+ * - getWsStreamUrl(): http(s) → ws(s) 변환 후 /ws/stream 경로 반환
+ */
+@Configuration
+public class FastApiConfig {
+
+    @Value("${fastapi.service.url:http://localhost:8000}")
+    private String fastapiServiceUrl;
+
+    @Bean(name = "fastapiOkHttpClient")
+    public OkHttpClient fastapiOkHttpClient() {
+        return new OkHttpClient.Builder()
+                .connectTimeout(5, TimeUnit.SECONDS)
+                .readTimeout(0, TimeUnit.SECONDS)       // WebSocket: 읽기 타임아웃 없음
+                .writeTimeout(10, TimeUnit.SECONDS)
+                .pingInterval(30, TimeUnit.SECONDS)     // 서버 keepalive
+                .build();
+    }
+
+    /**
+     * FastAPI WebSocket 스트림 URL
+     * application.yml: fastapi.service.url=http://localhost:8000
+     * → ws://localhost:8000/ws/stream
+     */
+    public String getWsStreamUrl() {
+        return fastapiServiceUrl
+                .replaceFirst("^https://", "wss://")
+                .replaceFirst("^http://", "ws://")
+                + "/ws/stream";
+    }
+}

--- a/guideon-kiosk-bff/src/main/resources/application-local.yml
+++ b/guideon-kiosk-bff/src/main/resources/application-local.yml
@@ -10,6 +10,10 @@ spring:
         format_sql: true
         show_sql: true
 
+fastapi:
+  service:
+    url: http://127.0.0.1:8000
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## Summary
- #127 
-

## Tasks
- [X] websocket 연결 
- [x] 연결 테스트 완료

## To Reviewer
### 연결 URL
ws://<host>:8082/ws/v1/kiosk/stt?sessionId=<채팅세션ID>&siteId=<사이트ID>&languageCode=ko-KR&sampleRate=16000&ttsStream=true&token=<device-token>

### Client → Server
오디오 | binary (PCM) | 마이크 입력 실시간 전송
종료 | {"type":"stop"} | 오디오 스트림 종료 신호

### Server → Client

| Type        | 주요 필드                           | 설명                           |
|-------------|------------------------------------|--------------------------------|
| `status`    | `stage`                            | 파이프라인 진행 상태           |
| `stt_interim` | `text`, `confidence`             | STT 중간 결과                  |
| `stt_final` | `text`, `confidence`               | STT 최종 결과                  |
| `tts_chunk` | `seq`, `text`, `audio_b64`, `is_final` | TTS 오디오 청크 (MP3, Base64) |
| `final_text` | `query`, `answer`                 | QA 최종 텍스트                 |
| `done`      | `-`                                | 파이프라인 완료                |
| `error`     | `code`, `message`                  | 오류                           |

### 흐름
1. WS 연결
2. Server → {"type":"status","stage":"stt_start"}  // 준비 완료
3. Client → binary PCM 청크 스트리밍
4. Server → {"type":"stt_interim", ...}             // 중간 인식
5. Client → {"type":"stop"}                         // 오디오 종료
6. Server → {"type":"stt_final", ...}               // 최종 인식
7. Server → {"type":"tts_chunk", "seq":0, ...}      // TTS 스트리밍
8. Server → {"type":"tts_chunk", "seq":1, "is_final":true, ...}
9. Server → {"type":"final_text", ...}
10. Server → {"type":"done"}                         // 완료


audio_b64 → Base64 디코딩 → MP3 bytes → 재생
seq 순서대로 재생, is_final=true이면 마지막 청크

### 오류 처리
FASTAPI_UNAVAILABLE(AI 서버 연결 실패),
EMPTY_TRANSCRIPT(음성 인식 실패)


모든 처리가 끝나면 {"type":"done"}이 옵니다.

## Screenshot
<img width="821" height="154" alt="image" src="https://github.com/user-attachments/assets/69f822ef-1c0c-49d7-a5f2-622dee3b5e49" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 키오스크와 FastAPI 간 양방향 실시간 STT WebSocket 스트리밍 지원 추가

* **개선 사항**
  * 스트리밍 안정성·신뢰성 향상 및 연결 수명주기 관리 개선
  * 오류 발생 시 더 명확한 오류 전달 포맷 제공

* **설정**
  * FastAPI 서비스 엔드포인트를 환경 설정으로 지정 가능하도록 추가 및 로컬 도커 기본 주소 변경(호스트 내부 주소 사용)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->