### PR TITLE
 fix: API 경로 prefix /api/v1 누락 수정

### DIFF
--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/auth/controller/KioskAuthController.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/auth/controller/KioskAuthController.java
@@ -16,7 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/kiosk")
+@RequestMapping("/api/v1/kiosk")
 @RequiredArgsConstructor
 public class KioskAuthController {
 

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/controller/KioskChatController.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/controller/KioskChatController.java
@@ -15,7 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/kiosk/chat")
+@RequestMapping("/api/v1/kiosk/chat")
 @RequiredArgsConstructor
 public class KioskChatController {
 

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/pairing/controller/KioskPairingController.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/pairing/controller/KioskPairingController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "키오스크 페어링", description = "키오스크 첫 부팅 시 페어링 코드 기반 등록")
 @RestController
-@RequestMapping("/kiosk/pairing")
+@RequestMapping("/api/v1/kiosk/pairing")
 @RequiredArgsConstructor
 public class KioskPairingController {
 

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/global/config/SecurityConfig.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/global/config/SecurityConfig.java
@@ -51,9 +51,9 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
                                 "/ws/**",  // WS 핸드셰이크는 인터셉터에서 직접 인증
-                                "/kiosk/pairing/**"  // 페어링은 토큰 없는 상태에서 호출
+                                "/api/v1/kiosk/pairing/**"  // 페어링은 토큰 없는 상태에서 호출
                         ).permitAll()
-                        .requestMatchers("/kiosk/**").hasRole("DEVICE")
+                        .requestMatchers("/api/v1/kiosk/**").hasRole("DEVICE")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(


### PR DESCRIPTION
## Summary
- #130
- Kiosk BFF 컨트롤러 3개의 `@RequestMapping`에 `/api/v1` prefix 추가 했습니다.
- `SecurityConfig`의 `requestMatchers` 경로도 동일하게 `/api/v1` prefix 적용 했습니다.
 - nginx가 `/api/v1/kiosk/**` 경로를 그대로 전달하는데 Spring 컨트롤러가 `/kiosk/**`로만 매핑되어 Unity 요청 시 401 발생하던 문제를 해결 했습니다

## Tasks
- [x] Unity에서 `POST /api/v1/kiosk/pairing/request` 호출 시 401 대신 정상 응답(200) 확인
- [ ] 

## To Reviewer
- 

## Screenshot
<img src="" width="50%" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 리팩토링

* **API 엔드포인트 경로 구조 업데이트**
  * 인증, 채팅, 페어링 관련 엔드포인트의 기본 경로가 변경되었습니다.
  * 보안 설정이 새로운 엔드포인트 경로와 동기화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->