### PR TITLE
[FIX] 이미지 업로드/조회 장애 수정

### DIFF
--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -42,6 +42,15 @@ server {
         # CORS는 Spring Security에서 처리 (중복 방지)
     }
 
+    # ===== 업로드 파일 서빙 (이미지/PDF) =====
+    location /internal/files/ {
+        proxy_pass http://admin-bff:8081;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # ===== Kiosk BFF (REST) =====
     location /api/v1/kiosk/ {
         proxy_pass http://kiosk-bff:8082;

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/client/CoreChatStatsClient.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/client/CoreChatStatsClient.java
@@ -1,0 +1,13 @@
+package com.guideon.guideonbackend.client;
+
+import com.guideon.core.dto.chat.QuestionTypeStatDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "core-chat-stats", url = "${core.service.url}")
+public interface CoreChatStatsClient {
+
+    @GetMapping("/internal/v1/chat/stats/question-types")
+    QuestionTypeStatDto getQuestionTypeStats(@RequestParam("siteId") Long siteId);
+}

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/controller/MascotController.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/controller/MascotController.java
@@ -79,15 +79,16 @@ public class MascotController {
 
     // ── 3D 모델 생성 (Tripo AI) ──
 
-    @Operation(summary = "3D 모델 생성 시작", description = "이미지를 업로드하여 Tripo AI 3D 모델 생성을 시작합니다. PLATFORM_ADMIN 권한 필요")
-    @PostMapping(value = "/generate", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "3D 모델 생성 시작",
+            description = "선업로드된 이미지 URL(POST /mascot/image 응답)을 받아 Tripo AI 3D 모델 생성을 시작합니다. PLATFORM_ADMIN 권한 필요")
+    @PostMapping("/generate")
     public ResponseEntity<ApiResponse<StartGenerationResponse>> startGeneration(
             @PathVariable Long siteId,
-            @RequestPart("file") MultipartFile file,
+            @Valid @RequestBody StartGenerationRequest request,
             @AuthenticationPrincipal CustomAdminDetails adminDetails,
             HttpServletRequest httpRequest
     ) {
-        StartGenerationResponse response = generationService.startGeneration(siteId, file, adminDetails);
+        StartGenerationResponse response = generationService.startGeneration(siteId, request.getImageUrl(), adminDetails);
         String traceId = (String) httpRequest.getAttribute(TraceIdUtil.TRACE_ID_ATTR);
         return ResponseEntity.ok(ApiResponse.success(response, traceId));
     }

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/dto/StartGenerationRequest.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/dto/StartGenerationRequest.java
@@ -1,10 +1,21 @@
 package com.guideon.guideonbackend.domain.mascot.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "마스코트 3D 모델 생성 요청")
 public class StartGenerationRequest {
-    // 이미지는 MultipartFile로 별도 수신, 추가 옵션 필요 시 여기에 추가
+
+    @Schema(description = "선업로드된 마스코트 이미지 URL (POST /mascot/image 응답값)",
+            example = "https://realguideon.duckdns.org/internal/files/1/abc123.png")
+    @NotBlank(message = "image_url은 필수입니다")
+    @Size(max = 500, message = "image_url은 500자 이하여야 합니다")
+    @JsonProperty("image_url")
+    private String imageUrl;
 }

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationService.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 /**
  * 마스코트 3D 모델 생성 파이프라인 오케스트레이션.
@@ -37,13 +36,12 @@ public class MascotGenerationService {
     private final FileStorageService fileStorageService;
 
     /**
-     * Step 1: 이미지 업로드 + Tripo 3D 생성 task 시작
+     * Step 1: 선업로드된 이미지 URL을 받아 Tripo 3D 생성 task 시작
      * 외부 API 호출 후 DB 저장 (트랜잭션 분리)
      */
-    public StartGenerationResponse startGeneration(Long siteId, MultipartFile imageFile,
+    public StartGenerationResponse startGeneration(Long siteId, String imageUrl,
                                                     CustomAdminDetails adminDetails) {
         validatePlatformAdmin(adminDetails);
-        FileValidator.validateImage(imageFile);
 
         Site site = siteRepository.findById(siteId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 관광지: " + siteId));
@@ -56,14 +54,15 @@ public class MascotGenerationService {
                             "이미 진행 중인 3D 생성 작업이 있습니다: " + gen.getGenerationId());
                 });
 
-        // 외부 IO (트랜잭션 밖)
-        String fileHash = FileValidator.computeFileHash(imageFile);
-        String sourceImageUrl = fileStorageService.store(siteId, fileHash, imageFile);
-        String imageToken = tripoApiService.uploadImage(imageFile);
+        // 선업로드된 이미지를 로컬에서 읽어 Tripo로 재전송
+        byte[] imageBytes = fileStorageService.loadBytes(siteId, imageUrl);
+        String filename = imageUrl.substring(imageUrl.lastIndexOf('/') + 1);
+
+        String imageToken = tripoApiService.uploadImage(imageBytes, filename);
         String modelTaskId = tripoApiService.createImageToModelTask(imageToken);
 
         // DB 저장 (별도 트랜잭션)
-        MascotGeneration generation = persistService.saveNewGeneration(site, sourceImageUrl, modelTaskId);
+        MascotGeneration generation = persistService.saveNewGeneration(site, imageUrl, modelTaskId);
 
         log.info("마스코트 3D 생성 시작: generationId={}, siteId={}, modelTaskId={}",
                 generation.getGenerationId(), siteId, modelTaskId);

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/TripoApiService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/TripoApiService.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
 
@@ -47,9 +46,9 @@ public class TripoApiService {
     }
 
     /**
-     * Step 1: 이미지 파일을 Tripo에 업로드 → file token 반환
+     * Step 1: 이미지 byte[]를 Tripo에 업로드 → file token 반환
      */
-    public String uploadImage(MultipartFile file) {
+    public String uploadImage(byte[] imageBytes, String filename) {
         String url = baseUrl + "/upload";
 
         HttpHeaders headers = new HttpHeaders();
@@ -57,17 +56,13 @@ public class TripoApiService {
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-        try {
-            ByteArrayResource resource = new ByteArrayResource(file.getBytes()) {
-                @Override
-                public String getFilename() {
-                    return file.getOriginalFilename();
-                }
-            };
-            body.add("file", resource);
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.TRIPO_API_ERROR, "이미지 읽기 실패: " + e.getMessage());
-        }
+        ByteArrayResource resource = new ByteArrayResource(imageBytes) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        };
+        body.add("file", resource);
 
         HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
 

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/stats/controller/StatsController.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/stats/controller/StatsController.java
@@ -1,0 +1,35 @@
+package com.guideon.guideonbackend.domain.stats.controller;
+
+import com.guideon.common.response.ApiResponse;
+import com.guideon.core.dto.chat.QuestionTypeStatDto;
+import com.guideon.guideonbackend.client.CoreChatStatsClient;
+import com.guideon.guideonbackend.global.trace.TraceIdUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "통계", description = "통계 API")
+@RestController
+@RequestMapping("/api/v1/admin/sites/{siteId}/stats")
+@RequiredArgsConstructor
+public class StatsController {
+
+    private final CoreChatStatsClient coreChatStatsClient;
+
+    @Operation(summary = "질문 유형 통계 조회", description = "사이트별 질문 유형(카테고리)별 통계를 조회합니다.")
+    @GetMapping("/question-types")
+    public ResponseEntity<ApiResponse<QuestionTypeStatDto>> getQuestionTypeStats(
+            @PathVariable Long siteId,
+            HttpServletRequest httpRequest
+    ) {
+        QuestionTypeStatDto result = coreChatStatsClient.getQuestionTypeStats(siteId);
+        String traceId = (String) httpRequest.getAttribute(TraceIdUtil.TRACE_ID_ATTR);
+        return ResponseEntity.ok(ApiResponse.success(result, traceId));
+    }
+}

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/FileDownloadController.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/FileDownloadController.java
@@ -14,12 +14,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.MalformedURLException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
- * 업로드된 파일을 HTTP로 제공하는 내부 엔드포인트.
- * FastAPI가 storage_url을 통해 PDF를 다운로드할 때 사용.
+ * 업로드된 파일을 HTTP로 제공하는 엔드포인트.
+ * - FastAPI가 storage_url을 통해 PDF를 다운로드할 때
+ * - 프론트가 <img>로 업로드된 이미지를 렌더링할 때
  */
 @Slf4j
 @RestController
@@ -34,19 +36,32 @@ public class FileDownloadController {
     public ResponseEntity<Resource> downloadFile(
             @PathVariable Long siteId,
             @PathVariable String filename) {
+
+        if (filename.contains("/") || filename.contains("\\") || filename.contains("..")) {
+            return ResponseEntity.badRequest().build();
+        }
+
         try {
-            Path filePath = Paths.get(uploadDir).toAbsolutePath().normalize()
+            Path baseDir = Paths.get(uploadDir).toAbsolutePath().normalize();
+            Path filePath = baseDir
                     .resolve(String.valueOf(siteId))
                     .resolve(filename)
                     .normalize();
+
+            if (!filePath.startsWith(baseDir)) {
+                log.warn("파일 다운로드 거부 - 허용된 디렉토리 외부: {}", filePath);
+                return ResponseEntity.badRequest().build();
+            }
 
             Resource resource = new UrlResource(filePath.toUri());
             if (!resource.exists() || !resource.isReadable()) {
                 return ResponseEntity.notFound().build();
             }
 
+            MediaType mediaType = resolveMediaType(filePath);
+
             return ResponseEntity.ok()
-                    .contentType(MediaType.APPLICATION_PDF)
+                    .contentType(mediaType)
                     .header(HttpHeaders.CONTENT_DISPOSITION,
                             "inline; filename=\"" + filename + "\"")
                     .body(resource);
@@ -55,5 +70,23 @@ public class FileDownloadController {
             log.error("파일 다운로드 실패: siteId={}, filename={}", siteId, filename, e);
             return ResponseEntity.badRequest().build();
         }
+    }
+
+    private MediaType resolveMediaType(Path filePath) {
+        try {
+            String probed = Files.probeContentType(filePath);
+            if (probed != null) {
+                return MediaType.parseMediaType(probed);
+            }
+        } catch (Exception ignored) {
+        }
+
+        String name = filePath.getFileName().toString().toLowerCase();
+        if (name.endsWith(".png")) return MediaType.IMAGE_PNG;
+        if (name.endsWith(".jpg") || name.endsWith(".jpeg")) return MediaType.IMAGE_JPEG;
+        if (name.endsWith(".webp")) return MediaType.parseMediaType("image/webp");
+        if (name.endsWith(".pdf")) return MediaType.APPLICATION_PDF;
+        if (name.endsWith(".glb")) return MediaType.parseMediaType("model/gltf-binary");
+        return MediaType.APPLICATION_OCTET_STREAM;
     }
 }

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/FileStorageService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/FileStorageService.java
@@ -12,5 +12,11 @@ public interface FileStorageService {
 
     String store(Long siteId, String fileHash, byte[] fileBytes, String originalName);
 
+    /**
+     * 저장된 파일을 URL로부터 다시 읽어 byte[]로 반환.
+     * 외부 API(Tripo 등)에 재전송할 때 사용.
+     */
+    byte[] loadBytes(Long siteId, String storageUrl);
+
     void delete(String storageUrl);
 }

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/LocalFileStorageService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/LocalFileStorageService.java
@@ -70,6 +70,44 @@ public class LocalFileStorageService implements FileStorageService {
     }
 
     @Override
+    public byte[] loadBytes(Long siteId, String storageUrl) {
+        if (storageUrl == null || storageUrl.isBlank()) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "storageUrl이 비어있습니다.");
+        }
+
+        String filename = extractFilename(storageUrl, siteId);
+
+        Path siteDir = uploadDir.resolve(String.valueOf(siteId)).normalize();
+        Path filePath = siteDir.resolve(filename).normalize();
+
+        if (!filePath.startsWith(siteDir)) {
+            log.warn("파일 읽기 거부 - 허용된 디렉토리 외부: storageUrl={}", storageUrl);
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "허용되지 않은 파일 경로입니다.");
+        }
+
+        try {
+            return Files.readAllBytes(filePath);
+        } catch (IOException e) {
+            log.error("파일 읽기 실패: siteId={}, storageUrl={}", siteId, storageUrl, e);
+            throw new CustomException(ErrorCode.NOT_FOUND, "저장된 파일을 찾을 수 없습니다: " + storageUrl);
+        }
+    }
+
+    private String extractFilename(String storageUrl, Long siteId) {
+        String marker = "/internal/files/" + siteId + "/";
+        int idx = storageUrl.indexOf(marker);
+        if (idx < 0) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR,
+                    "이 사이트에 속하지 않는 파일 URL입니다.");
+        }
+        String filename = storageUrl.substring(idx + marker.length());
+        if (filename.isBlank() || filename.contains("/") || filename.contains("\\") || filename.contains("..")) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "잘못된 파일명입니다.");
+        }
+        return filename;
+    }
+
+    @Override
     public void delete(String storageUrl) {
         try {
             Path filePath = Paths.get(storageUrl).normalize();

--- a/guideon-admin-bff/src/main/resources/application.yml
+++ b/guideon-admin-bff/src/main/resources/application.yml
@@ -55,6 +55,17 @@ spring:
       host: ${SPRING_DATA_REDIS_HOST}
       port: ${SPRING_DATA_REDIS_PORT}
 
+  # Feign
+  cloud:
+    openfeign:
+      okhttp:
+        enabled: true
+      client:
+        config:
+          default:
+            connect-timeout: 5000
+            read-timeout: 10000
+
 # Logging (production default)
 logging:
   level:
@@ -76,17 +87,6 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-validity-ms: 900000      # 15분
   refresh-token-validity-ms: 2592000000 # 30일
-
-# Feign
-spring.cloud.openfeign.okhttp.enabled: true
-spring:
-  cloud:
-    openfeign:
-      client:
-        config:
-          default:
-            connect-timeout: 5000
-            read-timeout: 10000
 
 # File Storage
 file:

--- a/guideon-admin-bff/src/main/resources/application.yml
+++ b/guideon-admin-bff/src/main/resources/application.yml
@@ -79,6 +79,14 @@ jwt:
 
 # Feign
 spring.cloud.openfeign.okhttp.enabled: true
+spring:
+  cloud:
+    openfeign:
+      client:
+        config:
+          default:
+            connect-timeout: 5000
+            read-timeout: 10000
 
 # File Storage
 file:

--- a/guideon-core/src/main/java/com/guideon/core/api/ChatInternalController.java
+++ b/guideon-core/src/main/java/com/guideon/core/api/ChatInternalController.java
@@ -2,7 +2,9 @@ package com.guideon.core.api;
 
 import com.guideon.core.dto.chat.ChatCommand;
 import com.guideon.core.dto.chat.ChatResult;
+import com.guideon.core.dto.chat.QuestionTypeStatDto;
 import com.guideon.core.service.ChatService;
+import com.guideon.core.service.ChatStatsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +22,7 @@ import java.util.Map;
 public class ChatInternalController {
 
     private final ChatService chatService;
+    private final ChatStatsService chatStatsService;
 
     @PostMapping("/sessions")
     public ResponseEntity<Map<String, String>> createSession(
@@ -51,5 +54,16 @@ public class ChatInternalController {
     ) {
         chatService.endSession(sessionId, deviceId);
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * GET /internal/v1/chat/stats/question-types?siteId={siteId}
+     * 사이트별 질문 유형 통계 조회 (Admin BFF에서 호출)
+     */
+    @GetMapping("/stats/question-types")
+    public ResponseEntity<QuestionTypeStatDto> getQuestionTypeStats(
+            @RequestParam Long siteId
+    ) {
+        return ResponseEntity.ok(chatStatsService.getQuestionTypeStats(siteId));
     }
 }

--- a/guideon-core/src/main/java/com/guideon/core/domain/chat/entity/ChatMessage.java
+++ b/guideon-core/src/main/java/com/guideon/core/domain/chat/entity/ChatMessage.java
@@ -56,7 +56,7 @@ public class ChatMessage {
 
     // --- 통계/분석용 ---
     @Column(name = "category", length = 30)
-    private String category;          // DIRECTION, HOURS, FACILITY, HISTORY, GENERAL 등
+    private String category;          // DIRECTION(길안내), INFORMATION(시설·역사 정보), OPERATION(운영·이벤트), SMALLTALK(일상대화), GENERAL(기타), ERROR(오류)
 
     @Column(name = "answer_found", nullable = false)
     private boolean answerFound;      // AI가 의미 있는 답변을 찾았는지

--- a/guideon-core/src/main/java/com/guideon/core/domain/chat/repository/ChatMessageRepository.java
+++ b/guideon-core/src/main/java/com/guideon/core/domain/chat/repository/ChatMessageRepository.java
@@ -2,10 +2,23 @@ package com.guideon.core.domain.chat.repository;
 
 import com.guideon.core.domain.chat.entity.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
     List<ChatMessage> findBySessionIdOrderByCreatedAtAsc(String sessionId);
+
+    @Query("SELECT m.category AS category, COUNT(m) AS count " +
+           "FROM ChatMessage m " +
+           "WHERE m.siteId = :siteId " +
+           "GROUP BY m.category")
+    List<CategoryCountProjection> countByCategoryForSite(@Param("siteId") Long siteId);
+
+    interface CategoryCountProjection {
+        String getCategory();
+        Long getCount();
+    }
 }

--- a/guideon-core/src/main/java/com/guideon/core/domain/chat/repository/ChatMessageRepository.java
+++ b/guideon-core/src/main/java/com/guideon/core/domain/chat/repository/ChatMessageRepository.java
@@ -11,10 +11,10 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     List<ChatMessage> findBySessionIdOrderByCreatedAtAsc(String sessionId);
 
-    @Query("SELECT m.category AS category, COUNT(m) AS count " +
+    @Query("SELECT COALESCE(m.category, 'GENERAL') AS category, COUNT(m) AS count " +
            "FROM ChatMessage m " +
            "WHERE m.siteId = :siteId " +
-           "GROUP BY m.category")
+           "GROUP BY COALESCE(m.category, 'GENERAL')")
     List<CategoryCountProjection> countByCategoryForSite(@Param("siteId") Long siteId);
 
     interface CategoryCountProjection {

--- a/guideon-core/src/main/java/com/guideon/core/dto/chat/QuestionTypeStatDto.java
+++ b/guideon-core/src/main/java/com/guideon/core/dto/chat/QuestionTypeStatDto.java
@@ -1,0 +1,28 @@
+package com.guideon.core.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 질문 유형 통계 DTO
+ *
+ * 카테고리별 질문 수 + 비율
+ * category 값: DIRECTION(길안내), INFORMATION(시설·역사 정보), OPERATION(운영·이벤트), SMALLTALK(일상대화), GENERAL(기타), ERROR(오류)
+ */
+@Getter
+@AllArgsConstructor
+public class QuestionTypeStatDto {
+
+    private final List<CategoryStat> categories;
+    private final long total;
+
+    @Getter
+    @AllArgsConstructor
+    public static class CategoryStat {
+        private final String category;
+        private final long count;
+        private final double ratio;
+    }
+}

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatStatsService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatStatsService.java
@@ -1,0 +1,38 @@
+package com.guideon.core.service;
+
+import com.guideon.core.domain.chat.repository.ChatMessageRepository;
+import com.guideon.core.dto.chat.QuestionTypeStatDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatStatsService {
+
+    private final ChatMessageRepository chatMessageRepository;
+
+    /**
+     * 사이트별 질문 유형 통계
+     * category 컬럼 GROUP BY → 비율 계산
+     */
+    public QuestionTypeStatDto getQuestionTypeStats(Long siteId) {
+        List<ChatMessageRepository.CategoryCountProjection> rows =
+                chatMessageRepository.countByCategoryForSite(siteId);
+
+        long total = rows.stream().mapToLong(ChatMessageRepository.CategoryCountProjection::getCount).sum();
+
+        List<QuestionTypeStatDto.CategoryStat> categories = rows.stream()
+                .map(row -> new QuestionTypeStatDto.CategoryStat(
+                        row.getCategory() != null ? row.getCategory() : "GENERAL",
+                        row.getCount(),
+                        total > 0 ? Math.round((double) row.getCount() / total * 1000) / 1000.0 : 0.0
+                ))
+                .toList();
+
+        return new QuestionTypeStatDto(categories, total);
+    }
+}

--- a/guideon-core/src/main/resources/application.yml
+++ b/guideon-core/src/main/resources/application.yml
@@ -29,12 +29,7 @@ spring:
       host: ${SPRING_DATA_REDIS_HOST}
       port: ${SPRING_DATA_REDIS_PORT}
 
-fastapi:
-  service:
-    url: ${FASTAPI_SERVICE_URL:http://host.docker.internal:8000}
-
-# Feign 타임아웃
-spring:
+  # Feign 타임아웃
   cloud:
     openfeign:
       client:
@@ -46,6 +41,10 @@ spring:
             read-timeout: 60000     # AI 응답 최대 60초
           fastapi-document:
             read-timeout: 10000     # 문서 처리 요청 (fire-and-forget)
+
+fastapi:
+  service:
+    url: ${FASTAPI_SERVICE_URL:http://host.docker.internal:8000}
 
 # Logging (production default)
 logging:

--- a/guideon-core/src/main/resources/application.yml
+++ b/guideon-core/src/main/resources/application.yml
@@ -33,6 +33,20 @@ fastapi:
   service:
     url: ${FASTAPI_SERVICE_URL:http://host.docker.internal:8000}
 
+# Feign 타임아웃
+spring:
+  cloud:
+    openfeign:
+      client:
+        config:
+          default:
+            connect-timeout: 5000
+            read-timeout: 30000
+          fastapi-qa:
+            read-timeout: 60000     # AI 응답 최대 60초
+          fastapi-document:
+            read-timeout: 10000     # 문서 처리 요청 (fire-and-forget)
+
 # Logging (production default)
 logging:
   level:

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/controller/KioskChatController.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/controller/KioskChatController.java
@@ -23,7 +23,7 @@ public class KioskChatController {
 
     /**
      * POST /api/v1/kiosk/chat/sessions
-     * 대화 세션 생성 (Core에서 UUID 생성 + DB 저장)
+     * 대화 세션 생성 (Core에서 UUID 생성 + DB 저장)git commit -m "fix(storage): 파일 응답 Content-Type 확장자 기반 동적 결정 (#138)
      */
     @PostMapping("/sessions")
     public ResponseEntity<ApiResponse<CreateSessionResponse>> createSession(

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/global/config/FastApiConfig.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/global/config/FastApiConfig.java
@@ -19,13 +19,18 @@ public class FastApiConfig {
     @Value("${fastapi.service.url:http://localhost:8000}")
     private String fastapiServiceUrl;
 
+    @Value("${fastapi.websocket.connect-timeout:5}") private int connectTimeout;
+    @Value("${fastapi.websocket.read-timeout:0}") private int readTimeout;
+    @Value("${fastapi.websocket.write-timeout:10}") private int writeTimeout;
+    @Value("${fastapi.websocket.ping-interval:30}") private int pingInterval;
+
     @Bean(name = "fastapiOkHttpClient")
     public OkHttpClient fastapiOkHttpClient() {
         return new OkHttpClient.Builder()
-                .connectTimeout(5, TimeUnit.SECONDS)
-                .readTimeout(0, TimeUnit.SECONDS)       // WebSocket: 읽기 타임아웃 없음
-                .writeTimeout(10, TimeUnit.SECONDS)
-                .pingInterval(30, TimeUnit.SECONDS)     // 서버 keepalive
+                .connectTimeout(connectTimeout, TimeUnit.SECONDS)
+                .readTimeout(readTimeout, TimeUnit.SECONDS)     // 0 = 무제한 (WebSocket keepalive)
+                .writeTimeout(writeTimeout, TimeUnit.SECONDS)
+                .pingInterval(pingInterval, TimeUnit.SECONDS)   // 서버 keepalive
                 .build();
     }
 

--- a/guideon-kiosk-bff/src/main/resources/application.yml
+++ b/guideon-kiosk-bff/src/main/resources/application.yml
@@ -38,3 +38,8 @@ core:
 fastapi:
   service:
     url: ${FASTAPI_SERVICE_URL:http://localhost:8000}
+  websocket:
+    connect-timeout: 5        # 초
+    read-timeout: 0           # 0 = 무제한 (WebSocket keepalive)
+    write-timeout: 10         # 초
+    ping-interval: 30         # 초

--- a/guideon-kiosk-bff/src/main/resources/application.yml
+++ b/guideon-kiosk-bff/src/main/resources/application.yml
@@ -21,21 +21,21 @@ spring:
       hibernate:
         default_batch_fetch_size: 100
 
-# Logging (production default)
-logging:
-  level:
-    org.springframework.web: info
-
-# Feign
-spring.cloud.openfeign.okhttp.enabled: true
-spring:
+  # Feign
   cloud:
     openfeign:
+      okhttp:
+        enabled: true
       client:
         config:
           default:
             connect-timeout: 5000
             read-timeout: 10000
+
+# Logging (production default)
+logging:
+  level:
+    org.springframework.web: info
 
 # Core Service (Internal API)
 core:

--- a/guideon-kiosk-bff/src/main/resources/application.yml
+++ b/guideon-kiosk-bff/src/main/resources/application.yml
@@ -28,6 +28,14 @@ logging:
 
 # Feign
 spring.cloud.openfeign.okhttp.enabled: true
+spring:
+  cloud:
+    openfeign:
+      client:
+        config:
+          default:
+            connect-timeout: 5000
+            read-timeout: 10000
 
 # Core Service (Internal API)
 core:


### PR DESCRIPTION
## Summary
- #138
- 업로드된 이미지 URL이 외부에서 404 나던 문제 수정 (nginx 라우팅 + Content-Type)
- 마스코트 3D 생성 API를 선업로드 `image_url` JSON 방식으로 전환 (Place 도메인과 일관성)


## To Reviewer
- **새 호출 흐름**: `POST /mascot/image` (multipart) → 응답 `image_url` 받기 → `POST /mascot/generate` body `{ "image_url": "..." }`
- 기존 multipart 방식의 `/generate`는 제거했습니다.
- `image_url`은 snake_case로 들어갑니다.
## Screenshot
<img src="" width="50%" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 관리자용 질문 유형 통계 조회 기능 추가
  * 마스코트 생성 워크플로우 개선 (사전 업로드된 이미지 URL 기반 처리)

* **개선 사항**
  * 파일 다운로드 보안 강화 (경로 조회 방지)
  * 파일 응답 콘텐츠 타입 동적 결정
  * 네트워크 요청 타임아웃 설정 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->