### PR TITLE
[FIX] 이미지 업로드/조회 장애 수정

### DIFF
--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -42,6 +42,15 @@ server {
         # CORS는 Spring Security에서 처리 (중복 방지)
     }
 
+    # ===== 업로드 파일 서빙 (이미지/PDF) =====
+    location /internal/files/ {
+        proxy_pass http://admin-bff:8081;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # ===== Kiosk BFF (REST) =====
     location /api/v1/kiosk/ {
         proxy_pass http://kiosk-bff:8082;

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/controller/MascotController.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/controller/MascotController.java
@@ -79,15 +79,16 @@ public class MascotController {
 
     // ── 3D 모델 생성 (Tripo AI) ──
 
-    @Operation(summary = "3D 모델 생성 시작", description = "이미지를 업로드하여 Tripo AI 3D 모델 생성을 시작합니다. PLATFORM_ADMIN 권한 필요")
-    @PostMapping(value = "/generate", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "3D 모델 생성 시작",
+            description = "선업로드된 이미지 URL(POST /mascot/image 응답)을 받아 Tripo AI 3D 모델 생성을 시작합니다. PLATFORM_ADMIN 권한 필요")
+    @PostMapping("/generate")
     public ResponseEntity<ApiResponse<StartGenerationResponse>> startGeneration(
             @PathVariable Long siteId,
-            @RequestPart("file") MultipartFile file,
+            @Valid @RequestBody StartGenerationRequest request,
             @AuthenticationPrincipal CustomAdminDetails adminDetails,
             HttpServletRequest httpRequest
     ) {
-        StartGenerationResponse response = generationService.startGeneration(siteId, file, adminDetails);
+        StartGenerationResponse response = generationService.startGeneration(siteId, request.getImageUrl(), adminDetails);
         String traceId = (String) httpRequest.getAttribute(TraceIdUtil.TRACE_ID_ATTR);
         return ResponseEntity.ok(ApiResponse.success(response, traceId));
     }

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/dto/StartGenerationRequest.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/dto/StartGenerationRequest.java
@@ -1,10 +1,21 @@
 package com.guideon.guideonbackend.domain.mascot.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "마스코트 3D 모델 생성 요청")
 public class StartGenerationRequest {
-    // 이미지는 MultipartFile로 별도 수신, 추가 옵션 필요 시 여기에 추가
+
+    @Schema(description = "선업로드된 마스코트 이미지 URL (POST /mascot/image 응답값)",
+            example = "https://realguideon.duckdns.org/internal/files/1/abc123.png")
+    @NotBlank(message = "image_url은 필수입니다")
+    @Size(max = 500, message = "image_url은 500자 이하여야 합니다")
+    @JsonProperty("image_url")
+    private String imageUrl;
 }

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationService.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 /**
  * 마스코트 3D 모델 생성 파이프라인 오케스트레이션.
@@ -37,13 +36,12 @@ public class MascotGenerationService {
     private final FileStorageService fileStorageService;
 
     /**
-     * Step 1: 이미지 업로드 + Tripo 3D 생성 task 시작
+     * Step 1: 선업로드된 이미지 URL을 받아 Tripo 3D 생성 task 시작
      * 외부 API 호출 후 DB 저장 (트랜잭션 분리)
      */
-    public StartGenerationResponse startGeneration(Long siteId, MultipartFile imageFile,
+    public StartGenerationResponse startGeneration(Long siteId, String imageUrl,
                                                     CustomAdminDetails adminDetails) {
         validatePlatformAdmin(adminDetails);
-        FileValidator.validateImage(imageFile);
 
         Site site = siteRepository.findById(siteId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 관광지: " + siteId));
@@ -56,14 +54,15 @@ public class MascotGenerationService {
                             "이미 진행 중인 3D 생성 작업이 있습니다: " + gen.getGenerationId());
                 });
 
-        // 외부 IO (트랜잭션 밖)
-        String fileHash = FileValidator.computeFileHash(imageFile);
-        String sourceImageUrl = fileStorageService.store(siteId, fileHash, imageFile);
-        String imageToken = tripoApiService.uploadImage(imageFile);
+        // 선업로드된 이미지를 로컬에서 읽어 Tripo로 재전송
+        byte[] imageBytes = fileStorageService.loadBytes(siteId, imageUrl);
+        String filename = imageUrl.substring(imageUrl.lastIndexOf('/') + 1);
+
+        String imageToken = tripoApiService.uploadImage(imageBytes, filename);
         String modelTaskId = tripoApiService.createImageToModelTask(imageToken);
 
         // DB 저장 (별도 트랜잭션)
-        MascotGeneration generation = persistService.saveNewGeneration(site, sourceImageUrl, modelTaskId);
+        MascotGeneration generation = persistService.saveNewGeneration(site, imageUrl, modelTaskId);
 
         log.info("마스코트 3D 생성 시작: generationId={}, siteId={}, modelTaskId={}",
                 generation.getGenerationId(), siteId, modelTaskId);

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/TripoApiService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/TripoApiService.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
 
@@ -47,9 +46,9 @@ public class TripoApiService {
     }
 
     /**
-     * Step 1: 이미지 파일을 Tripo에 업로드 → file token 반환
+     * Step 1: 이미지 byte[]를 Tripo에 업로드 → file token 반환
      */
-    public String uploadImage(MultipartFile file) {
+    public String uploadImage(byte[] imageBytes, String filename) {
         String url = baseUrl + "/upload";
 
         HttpHeaders headers = new HttpHeaders();
@@ -57,17 +56,13 @@ public class TripoApiService {
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-        try {
-            ByteArrayResource resource = new ByteArrayResource(file.getBytes()) {
-                @Override
-                public String getFilename() {
-                    return file.getOriginalFilename();
-                }
-            };
-            body.add("file", resource);
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.TRIPO_API_ERROR, "이미지 읽기 실패: " + e.getMessage());
-        }
+        ByteArrayResource resource = new ByteArrayResource(imageBytes) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        };
+        body.add("file", resource);
 
         HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
 

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/FileDownloadController.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/FileDownloadController.java
@@ -14,12 +14,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.MalformedURLException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
- * 업로드된 파일을 HTTP로 제공하는 내부 엔드포인트.
- * FastAPI가 storage_url을 통해 PDF를 다운로드할 때 사용.
+ * 업로드된 파일을 HTTP로 제공하는 엔드포인트.
+ * - FastAPI가 storage_url을 통해 PDF를 다운로드할 때
+ * - 프론트가 <img>로 업로드된 이미지를 렌더링할 때
  */
 @Slf4j
 @RestController
@@ -34,19 +36,32 @@ public class FileDownloadController {
     public ResponseEntity<Resource> downloadFile(
             @PathVariable Long siteId,
             @PathVariable String filename) {
+
+        if (filename.contains("/") || filename.contains("\\") || filename.contains("..")) {
+            return ResponseEntity.badRequest().build();
+        }
+
         try {
-            Path filePath = Paths.get(uploadDir).toAbsolutePath().normalize()
+            Path baseDir = Paths.get(uploadDir).toAbsolutePath().normalize();
+            Path filePath = baseDir
                     .resolve(String.valueOf(siteId))
                     .resolve(filename)
                     .normalize();
+
+            if (!filePath.startsWith(baseDir)) {
+                log.warn("파일 다운로드 거부 - 허용된 디렉토리 외부: {}", filePath);
+                return ResponseEntity.badRequest().build();
+            }
 
             Resource resource = new UrlResource(filePath.toUri());
             if (!resource.exists() || !resource.isReadable()) {
                 return ResponseEntity.notFound().build();
             }
 
+            MediaType mediaType = resolveMediaType(filePath);
+
             return ResponseEntity.ok()
-                    .contentType(MediaType.APPLICATION_PDF)
+                    .contentType(mediaType)
                     .header(HttpHeaders.CONTENT_DISPOSITION,
                             "inline; filename=\"" + filename + "\"")
                     .body(resource);
@@ -55,5 +70,23 @@ public class FileDownloadController {
             log.error("파일 다운로드 실패: siteId={}, filename={}", siteId, filename, e);
             return ResponseEntity.badRequest().build();
         }
+    }
+
+    private MediaType resolveMediaType(Path filePath) {
+        try {
+            String probed = Files.probeContentType(filePath);
+            if (probed != null) {
+                return MediaType.parseMediaType(probed);
+            }
+        } catch (Exception ignored) {
+        }
+
+        String name = filePath.getFileName().toString().toLowerCase();
+        if (name.endsWith(".png")) return MediaType.IMAGE_PNG;
+        if (name.endsWith(".jpg") || name.endsWith(".jpeg")) return MediaType.IMAGE_JPEG;
+        if (name.endsWith(".webp")) return MediaType.parseMediaType("image/webp");
+        if (name.endsWith(".pdf")) return MediaType.APPLICATION_PDF;
+        if (name.endsWith(".glb")) return MediaType.parseMediaType("model/gltf-binary");
+        return MediaType.APPLICATION_OCTET_STREAM;
     }
 }

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/FileStorageService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/FileStorageService.java
@@ -12,5 +12,11 @@ public interface FileStorageService {
 
     String store(Long siteId, String fileHash, byte[] fileBytes, String originalName);
 
+    /**
+     * 저장된 파일을 URL로부터 다시 읽어 byte[]로 반환.
+     * 외부 API(Tripo 등)에 재전송할 때 사용.
+     */
+    byte[] loadBytes(Long siteId, String storageUrl);
+
     void delete(String storageUrl);
 }

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/LocalFileStorageService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/LocalFileStorageService.java
@@ -70,6 +70,44 @@ public class LocalFileStorageService implements FileStorageService {
     }
 
     @Override
+    public byte[] loadBytes(Long siteId, String storageUrl) {
+        if (storageUrl == null || storageUrl.isBlank()) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "storageUrl이 비어있습니다.");
+        }
+
+        String filename = extractFilename(storageUrl, siteId);
+
+        Path siteDir = uploadDir.resolve(String.valueOf(siteId)).normalize();
+        Path filePath = siteDir.resolve(filename).normalize();
+
+        if (!filePath.startsWith(siteDir)) {
+            log.warn("파일 읽기 거부 - 허용된 디렉토리 외부: storageUrl={}", storageUrl);
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "허용되지 않은 파일 경로입니다.");
+        }
+
+        try {
+            return Files.readAllBytes(filePath);
+        } catch (IOException e) {
+            log.error("파일 읽기 실패: siteId={}, storageUrl={}", siteId, storageUrl, e);
+            throw new CustomException(ErrorCode.NOT_FOUND, "저장된 파일을 찾을 수 없습니다: " + storageUrl);
+        }
+    }
+
+    private String extractFilename(String storageUrl, Long siteId) {
+        String marker = "/internal/files/" + siteId + "/";
+        int idx = storageUrl.indexOf(marker);
+        if (idx < 0) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR,
+                    "이 사이트에 속하지 않는 파일 URL입니다.");
+        }
+        String filename = storageUrl.substring(idx + marker.length());
+        if (filename.isBlank() || filename.contains("/") || filename.contains("\\") || filename.contains("..")) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "잘못된 파일명입니다.");
+        }
+        return filename;
+    }
+
+    @Override
     public void delete(String storageUrl) {
         try {
             Path filePath = Paths.get(storageUrl).normalize();

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/controller/KioskChatController.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/chat/controller/KioskChatController.java
@@ -23,7 +23,7 @@ public class KioskChatController {
 
     /**
      * POST /api/v1/kiosk/chat/sessions
-     * 대화 세션 생성 (Core에서 UUID 생성 + DB 저장)
+     * 대화 세션 생성 (Core에서 UUID 생성 + DB 저장)git commit -m "fix(storage): 파일 응답 Content-Type 확장자 기반 동적 결정 (#138)
      */
     @PostMapping("/sessions")
     public ResponseEntity<ApiResponse<CreateSessionResponse>> createSession(


### PR DESCRIPTION
## Summary
- #138
- 업로드된 이미지 URL이 외부에서 404 나던 문제 수정 (nginx 라우팅 + Content-Type)
- 마스코트 3D 생성 API를 선업로드 `image_url` JSON 방식으로 전환 (Place 도메인과 일관성)


## To Reviewer
- **새 호출 흐름**: `POST /mascot/image` (multipart) → 응답 `image_url` 받기 → `POST /mascot/generate` body `{ "image_url": "..." }`
- 기존 multipart 방식의 `/generate`는 제거했습니다.
- `image_url`은 snake_case로 들어갑니다.
## Screenshot
<img src="" width="50%" />