### PR TITLE
Feat/tts websocket

### DIFF
--- a/guideon-core/src/main/java/com/guideon/core/api/ChatInternalController.java
+++ b/guideon-core/src/main/java/com/guideon/core/api/ChatInternalController.java
@@ -66,7 +66,7 @@ public class ChatInternalController {
             @PathVariable String sessionId,
             @RequestBody WsChatSaveCommand command
     ) {
-        chatService.saveWsMessage(command);
+        chatService.saveWsMessage(sessionId, command);
         return ResponseEntity.ok().build();
     }
 

--- a/guideon-core/src/main/java/com/guideon/core/api/ChatInternalController.java
+++ b/guideon-core/src/main/java/com/guideon/core/api/ChatInternalController.java
@@ -2,6 +2,7 @@ package com.guideon.core.api;
 
 import com.guideon.core.dto.chat.ChatCommand;
 import com.guideon.core.dto.chat.ChatResult;
+import com.guideon.core.dto.chat.WsChatSaveCommand;
 import com.guideon.core.dto.chat.QuestionTypeStatDto;
 import com.guideon.core.service.ChatService;
 import com.guideon.core.service.ChatStatsService;
@@ -53,6 +54,19 @@ public class ChatInternalController {
             @RequestParam String deviceId
     ) {
         chatService.endSession(sessionId, deviceId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * POST /internal/v1/chat/sessions/{sessionId}/ws-message
+     * WebSocket STT 파이프라인 완료 후 채팅 이력 저장 (Kiosk BFF 호출)
+     */
+    @PostMapping("/sessions/{sessionId}/ws-message")
+    public ResponseEntity<Void> saveWsMessage(
+            @PathVariable String sessionId,
+            @RequestBody WsChatSaveCommand command
+    ) {
+        chatService.saveWsMessage(command);
         return ResponseEntity.ok().build();
     }
 

--- a/guideon-core/src/main/java/com/guideon/core/dto/chat/WsChatSaveCommand.java
+++ b/guideon-core/src/main/java/com/guideon/core/dto/chat/WsChatSaveCommand.java
@@ -22,4 +22,5 @@ public class WsChatSaveCommand {
     private String answer;
     private String language;
     private String category;
+    private Boolean answerFound;
 }

--- a/guideon-core/src/main/java/com/guideon/core/dto/chat/WsChatSaveCommand.java
+++ b/guideon-core/src/main/java/com/guideon/core/dto/chat/WsChatSaveCommand.java
@@ -21,4 +21,5 @@ public class WsChatSaveCommand {
     private String question;
     private String answer;
     private String language;
+    private String category;
 }

--- a/guideon-core/src/main/java/com/guideon/core/dto/chat/WsChatSaveCommand.java
+++ b/guideon-core/src/main/java/com/guideon/core/dto/chat/WsChatSaveCommand.java
@@ -23,4 +23,5 @@ public class WsChatSaveCommand {
     private String language;
     private String category;
     private Boolean answerFound;
+    private Long responseTimeMs;
 }

--- a/guideon-core/src/main/java/com/guideon/core/dto/chat/WsChatSaveCommand.java
+++ b/guideon-core/src/main/java/com/guideon/core/dto/chat/WsChatSaveCommand.java
@@ -1,0 +1,24 @@
+package com.guideon.core.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * WebSocket STT 파이프라인 완료 후 Kiosk BFF → Core 채팅 이력 저장 요청
+ *
+ * HTTP 채팅(ChatCommand)과 달리 FastAPI QA 결과를 BFF가 받아서 전달.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WsChatSaveCommand {
+    private String sessionId;
+    private String deviceId;
+    private Long siteId;
+    private String question;
+    private String answer;
+    private String language;
+}

--- a/guideon-core/src/main/java/com/guideon/core/dto/kiosk/KioskMascotDto.java
+++ b/guideon-core/src/main/java/com/guideon/core/dto/kiosk/KioskMascotDto.java
@@ -21,6 +21,8 @@ public class KioskMascotDto {
     private String modelFormat;
     private String defaultAnim;
     private String greetingMsg;
+    private String systemPrompt;
+    private Map<String, Object> promptConfig;
     private String ttsVoiceId;
     private Map<String, Object> ttsVoiceJson;
 
@@ -33,6 +35,8 @@ public class KioskMascotDto {
                 .modelFormat(mascot.getModelFormat())
                 .defaultAnim(mascot.getDefaultAnim())
                 .greetingMsg(mascot.getGreetingMsg())
+                .systemPrompt(mascot.getSystemPrompt())
+                .promptConfig(mascot.getPromptConfig())
                 .ttsVoiceId(mascot.getTtsVoiceId())
                 .ttsVoiceJson(mascot.getTtsVoiceJson())
                 .build();

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
@@ -16,6 +16,7 @@ import com.guideon.core.domain.zone.entity.Zone;
 import com.guideon.core.domain.zone.entity.ZoneType;
 import com.guideon.core.dto.chat.ChatCommand;
 import com.guideon.core.dto.chat.ChatResult;
+import com.guideon.core.dto.chat.WsChatSaveCommand;
 import com.guideon.core.dto.dailyinfo.DailyInfoDto;
 import com.guideon.core.dto.qa.QaRequest;
 import com.guideon.core.dto.qa.QaResponse;
@@ -296,6 +297,36 @@ public class ChatService {
                     .answerFound(false)
                     .build();
         }
+    }
+
+    /**
+     * WebSocket STT 파이프라인 완료 후 채팅 이력 저장.
+     * FastAPI QA 결과를 Kiosk BFF가 받아서 전달하는 경우에 사용.
+     */
+    @Transactional
+    public void saveWsMessage(WsChatSaveCommand command) {
+        ChatMessage chatMessage = ChatMessage.builder()
+                .sessionId(command.getSessionId())
+                .siteId(command.getSiteId())
+                .deviceId(command.getDeviceId())
+                .question(command.getQuestion())
+                .answer(command.getAnswer())
+                .language(command.getLanguage())
+                .answerFound(command.getAnswer() != null && !command.getAnswer().isBlank())
+                .category("GENERAL")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        chatMessageRepository.save(chatMessage);
+
+        final String question = command.getQuestion();
+        final String answer = command.getAnswer();
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                chatHistoryService.saveTurn(command.getSessionId(), question, answer);
+            }
+        });
     }
 
     private ChatResult buildChatResult(String sessionId, ChatCommand command, QaResponse qaResponse) {

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
@@ -31,6 +31,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -304,11 +305,43 @@ public class ChatService {
      * FastAPI QA 결과를 Kiosk BFF가 받아서 전달하는 경우에 사용.
      */
     @Transactional
-    public void saveWsMessage(WsChatSaveCommand command) {
+    public void saveWsMessage(String sessionId, WsChatSaveCommand command) {
+        if (command == null) {
+            throw new IllegalArgumentException("WS chat save command is required");
+        }
+
+        if (command.getSessionId() != null && !Objects.equals(sessionId, command.getSessionId())) {
+            log.warn("WS chat save rejected: path/body sessionId mismatch. pathSessionId={}", sessionId);
+            throw new IllegalArgumentException("sessionId mismatch");
+        }
+
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> {
+                    log.warn("WS chat save rejected: session not found. sessionId={}", sessionId);
+                    return new IllegalArgumentException("invalid session: " + sessionId);
+                });
+
+        if (session.getEndedAt() != null) {
+            log.warn("WS chat save rejected: session already ended. sessionId={}", sessionId);
+            throw new IllegalStateException("session already ended: " + sessionId);
+        }
+
+        if (command.getSiteId() != null && !Objects.equals(session.getSiteId(), command.getSiteId())) {
+            log.warn("WS chat save rejected: siteId mismatch. sessionId={}", sessionId);
+            throw new SecurityException("siteId mismatch for session: " + sessionId);
+        }
+
+        if (command.getDeviceId() != null && !Objects.equals(session.getDeviceId(), command.getDeviceId())) {
+            log.warn("WS chat save rejected: deviceId mismatch. sessionId={}", sessionId);
+            throw new SecurityException("deviceId mismatch for session: " + sessionId);
+        }
+
+        session.incrementMessageCount();
+
         ChatMessage chatMessage = ChatMessage.builder()
-                .sessionId(command.getSessionId())
-                .siteId(command.getSiteId())
-                .deviceId(command.getDeviceId())
+                .sessionId(sessionId)
+                .siteId(session.getSiteId())
+                .deviceId(session.getDeviceId())
                 .question(command.getQuestion())
                 .answer(command.getAnswer())
                 .language(command.getLanguage())
@@ -324,7 +357,7 @@ public class ChatService {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                chatHistoryService.saveTurn(command.getSessionId(), question, answer);
+                chatHistoryService.saveTurn(sessionId, question, answer);
             }
         });
     }

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
@@ -343,6 +343,15 @@ public class ChatService {
 
         session.incrementMessageCount();
 
+        String category = (command.getCategory() == null || command.getCategory().isBlank())
+                ? "GENERAL"
+                : command.getCategory();
+        boolean answerFound = command.getAnswerFound() != null
+                ? command.getAnswerFound()
+                : command.getAnswer() != null
+                && !command.getAnswer().isBlank()
+                && !"ERROR".equalsIgnoreCase(category);
+
         ChatMessage chatMessage = ChatMessage.builder()
                 .sessionId(sessionId)
                 .siteId(session.getSiteId())
@@ -350,8 +359,8 @@ public class ChatService {
                 .question(command.getQuestion())
                 .answer(command.getAnswer())
                 .language(command.getLanguage())
-                .answerFound(command.getAnswer() != null && !command.getAnswer().isBlank())
-                .category(command.getCategory() != null ? command.getCategory() : "GENERAL")
+                .answerFound(answerFound)
+                .category(category)
                 .createdAt(LocalDateTime.now())
                 .build();
 

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
@@ -361,6 +361,7 @@ public class ChatService {
                 .language(command.getLanguage())
                 .answerFound(answerFound)
                 .category(category)
+                .responseTimeMs(command.getResponseTimeMs())
                 .createdAt(LocalDateTime.now())
                 .build();
 

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
@@ -205,8 +205,13 @@ public class ChatService {
     public List<NearbyPlaceProjection> getNearbyPlacesByCategory(Long siteId, String deviceId, String category) {
         try {
             Device device = deviceRepository.findById(deviceId).orElse(null);
-            if (device == null || device.getLocation() == null) {
-                log.warn("Device 없음 또는 위치 미설정: deviceId=***");
+            if (device == null || device.getSite() == null || !Objects.equals(device.getSite().getSiteId(), siteId)) {
+                log.warn("Device 없음 또는 siteId 불일치: deviceId=***");
+                return List.of();
+            }
+
+            if (device.getLocation() == null) {
+                log.warn("Device 위치 미설정: deviceId=***");
                 return List.of();
             }
 

--- a/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/ChatService.java
@@ -313,7 +313,7 @@ public class ChatService {
                 .answer(command.getAnswer())
                 .language(command.getLanguage())
                 .answerFound(command.getAnswer() != null && !command.getAnswer().isBlank())
-                .category("GENERAL")
+                .category(command.getCategory() != null ? command.getCategory() : "GENERAL")
                 .createdAt(LocalDateTime.now())
                 .build();
 

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/client/CoreChatClient.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/client/CoreChatClient.java
@@ -2,6 +2,7 @@ package com.guideon.kiosk.client;
 
 import com.guideon.core.dto.chat.ChatCommand;
 import com.guideon.core.dto.chat.ChatResult;
+import com.guideon.core.dto.chat.WsChatSaveCommand;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,5 +31,11 @@ public interface CoreChatClient {
     void endSession(
             @PathVariable String sessionId,
             @RequestParam String deviceId
+    );
+
+    @PostMapping("/internal/v1/chat/sessions/{sessionId}/ws-message")
+    void saveWsMessage(
+            @PathVariable String sessionId,
+            @RequestBody WsChatSaveCommand command
     );
 }

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/client/CoreDailyInfoClient.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/client/CoreDailyInfoClient.java
@@ -2,14 +2,20 @@ package com.guideon.kiosk.client;
 
 import com.guideon.core.dto.dailyinfo.DailyInfoDto;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @FeignClient(name = "core-daily-info", url = "${core.service.url}")
 public interface CoreDailyInfoClient {
 
     @GetMapping("/internal/v1/sites/{siteId}/daily-infos")
-    List<DailyInfoDto> getDailyInfos(@PathVariable Long siteId);
+    List<DailyInfoDto> getDailyInfos(
+            @PathVariable Long siteId,
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    );
 }

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/client/CoreDailyInfoClient.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/client/CoreDailyInfoClient.java
@@ -1,0 +1,15 @@
+package com.guideon.kiosk.client;
+
+import com.guideon.core.dto.dailyinfo.DailyInfoDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@FeignClient(name = "core-daily-info", url = "${core.service.url}")
+public interface CoreDailyInfoClient {
+
+    @GetMapping("/internal/v1/sites/{siteId}/daily-infos")
+    List<DailyInfoDto> getDailyInfos(@PathVariable Long siteId);
+}

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
@@ -48,7 +48,7 @@ public class FastApiStreamSession {
     private volatile boolean closed = false;
     private volatile boolean ready = false;
 
-    /** final_text 수신 시 호출 — (query, answer, category) */
+    /** final_text 수신 시 호출 — (query, answer, category, answerFound, responseTimeMs) */
     private final OnFinalText onFinalText;
 
     /** onOpen() 전에 도착한 프레임을 임시 보관 (binary: byte[], text: String) */
@@ -60,7 +60,7 @@ public class FastApiStreamSession {
      * @param unitySession   Unity ↔ BFF Spring WebSocket 세션
      * @param sessionId      채팅 sessionId (로깅용)
      * @param startPayload   FastAPI에 최초 전송할 JSON {"type":"start", ...}
-     * @param onFinalText    final_text 수신 시 콜백 (query, answer, category) — 채팅 이력 저장용
+     * @param onFinalText    final_text 수신 시 콜백 (query, answer, category, answerFound, responseTimeMs) — 채팅 이력 저장용
      */
     public FastApiStreamSession(
             OkHttpClient okHttpClient,

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
@@ -1,5 +1,7 @@
 package com.guideon.kiosk.domain.stt.handler;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -12,6 +14,7 @@ import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.BiConsumer;
 
 /**
  * FastAPI /ws/stream WebSocket 연결 관리
@@ -33,11 +36,16 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 @Slf4j
 public class FastApiStreamSession {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     private final WebSocketSession unitySession;
     private final String sessionId;
     private volatile WebSocket fastapiWs;
     private volatile boolean closed = false;
     private volatile boolean ready = false;
+
+    /** final_text 수신 시 호출 — (query, answer) */
+    private final BiConsumer<String, String> onFinalText;
 
     /** onOpen() 전에 도착한 프레임을 임시 보관 (binary: byte[], text: String) */
     private final ConcurrentLinkedQueue<Object> pendingQueue = new ConcurrentLinkedQueue<>();
@@ -48,16 +56,19 @@ public class FastApiStreamSession {
      * @param unitySession   Unity ↔ BFF Spring WebSocket 세션
      * @param sessionId      채팅 sessionId (로깅용)
      * @param startPayload   FastAPI에 최초 전송할 JSON {"type":"start", ...}
+     * @param onFinalText    final_text 수신 시 콜백 (query, answer) — 채팅 이력 저장용
      */
     public FastApiStreamSession(
             OkHttpClient okHttpClient,
             String wsUrl,
             WebSocketSession unitySession,
             String sessionId,
-            String startPayload
+            String startPayload,
+            BiConsumer<String, String> onFinalText
     ) {
         this.unitySession = unitySession;
         this.sessionId = sessionId;
+        this.onFinalText = onFinalText != null ? onFinalText : (q, a) -> {};
 
         Request request = new Request.Builder().url(wsUrl).build();
         fastapiWs = okHttpClient.newWebSocket(request, new FastApiListener(startPayload));
@@ -120,11 +131,26 @@ public class FastApiStreamSession {
         public void onMessage(WebSocket webSocket, String text) {
             if (text == null) return;
             try {
+                interceptFinalText(text);
                 if (unitySession.isOpen()) {
                     unitySession.sendMessage(new TextMessage(text));
                 }
             } catch (IOException e) {
                 log.error("[FastApiStream] Unity 전송 실패: sessionId={}, error={}", sessionId, e.getMessage());
+            }
+        }
+
+        private void interceptFinalText(String text) {
+            try {
+                JsonNode node = MAPPER.readTree(text);
+                if (!"final_text".equals(node.path("type").asText())) return;
+                String query = node.path("query").asText(null);
+                String answer = node.path("answer").asText(null);
+                if (query != null && answer != null) {
+                    onFinalText.accept(query, answer);
+                }
+            } catch (Exception e) {
+                log.debug("[FastApiStream] final_text 파싱 실패 (무시): sessionId={}", sessionId);
             }
         }
 

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
@@ -37,7 +37,7 @@ public class FastApiStreamSession {
 
     @FunctionalInterface
     public interface OnFinalText {
-        void accept(String query, String answer, String category);
+        void accept(String query, String answer, String category, Boolean answerFound);
     }
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -72,7 +72,7 @@ public class FastApiStreamSession {
     ) {
         this.unitySession = unitySession;
         this.sessionId = sessionId;
-        this.onFinalText = onFinalText != null ? onFinalText : (q, a, c) -> {};
+        this.onFinalText = onFinalText != null ? onFinalText : (q, a, c, f) -> {};
 
         Request request = new Request.Builder().url(wsUrl).build();
         fastapiWs = okHttpClient.newWebSocket(request, new FastApiListener(startPayload));
@@ -150,13 +150,30 @@ public class FastApiStreamSession {
                 if (!"final_text".equals(node.path("type").asText())) return;
                 String query = node.path("query").asText(null);
                 String answer = node.path("answer").asText(null);
-                String category = node.path("category").asText("GENERAL");
+                String category = normalizeCategory(node.path("category").asText(null));
+                Boolean answerFound = parseAnswerFound(node);
                 if (query != null && answer != null) {
-                    onFinalText.accept(query, answer, category);
+                    Thread.ofVirtual().start(() -> {
+                        try {
+                            onFinalText.accept(query, answer, category, answerFound);
+                        } catch (Exception e) {
+                            log.warn("[FastApiStream] final_text 후처리 실패: sessionId={}, error={}",
+                                    sessionId, e.getMessage());
+                        }
+                    });
                 }
             } catch (Exception e) {
                 log.debug("[FastApiStream] final_text 파싱 실패 (무시): sessionId={}", sessionId);
             }
+        }
+
+        private String normalizeCategory(String category) {
+            return category == null || category.isBlank() ? "GENERAL" : category;
+        }
+
+        private Boolean parseAnswerFound(JsonNode node) {
+            JsonNode answerFound = node.has("answerFound") ? node.get("answerFound") : node.get("answer_found");
+            return answerFound == null || answerFound.isNull() ? null : answerFound.asBoolean();
         }
 
         @Override

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
@@ -14,7 +14,6 @@ import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.function.BiConsumer;
 
 /**
  * FastAPI /ws/stream WebSocket 연결 관리
@@ -36,6 +35,11 @@ import java.util.function.BiConsumer;
 @Slf4j
 public class FastApiStreamSession {
 
+    @FunctionalInterface
+    public interface OnFinalText {
+        void accept(String query, String answer, String category);
+    }
+
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final WebSocketSession unitySession;
@@ -44,8 +48,8 @@ public class FastApiStreamSession {
     private volatile boolean closed = false;
     private volatile boolean ready = false;
 
-    /** final_text 수신 시 호출 — (query, answer) */
-    private final BiConsumer<String, String> onFinalText;
+    /** final_text 수신 시 호출 — (query, answer, category) */
+    private final OnFinalText onFinalText;
 
     /** onOpen() 전에 도착한 프레임을 임시 보관 (binary: byte[], text: String) */
     private final ConcurrentLinkedQueue<Object> pendingQueue = new ConcurrentLinkedQueue<>();
@@ -56,7 +60,7 @@ public class FastApiStreamSession {
      * @param unitySession   Unity ↔ BFF Spring WebSocket 세션
      * @param sessionId      채팅 sessionId (로깅용)
      * @param startPayload   FastAPI에 최초 전송할 JSON {"type":"start", ...}
-     * @param onFinalText    final_text 수신 시 콜백 (query, answer) — 채팅 이력 저장용
+     * @param onFinalText    final_text 수신 시 콜백 (query, answer, category) — 채팅 이력 저장용
      */
     public FastApiStreamSession(
             OkHttpClient okHttpClient,
@@ -64,11 +68,11 @@ public class FastApiStreamSession {
             WebSocketSession unitySession,
             String sessionId,
             String startPayload,
-            BiConsumer<String, String> onFinalText
+            OnFinalText onFinalText
     ) {
         this.unitySession = unitySession;
         this.sessionId = sessionId;
-        this.onFinalText = onFinalText != null ? onFinalText : (q, a) -> {};
+        this.onFinalText = onFinalText != null ? onFinalText : (q, a, c) -> {};
 
         Request request = new Request.Builder().url(wsUrl).build();
         fastapiWs = okHttpClient.newWebSocket(request, new FastApiListener(startPayload));
@@ -146,8 +150,9 @@ public class FastApiStreamSession {
                 if (!"final_text".equals(node.path("type").asText())) return;
                 String query = node.path("query").asText(null);
                 String answer = node.path("answer").asText(null);
+                String category = node.path("category").asText("GENERAL");
                 if (query != null && answer != null) {
-                    onFinalText.accept(query, answer);
+                    onFinalText.accept(query, answer, category);
                 }
             } catch (Exception e) {
                 log.debug("[FastApiStream] final_text 파싱 실패 (무시): sessionId={}", sessionId);

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
@@ -135,13 +135,13 @@ public class FastApiStreamSession {
         public void onMessage(WebSocket webSocket, String text) {
             if (text == null) return;
             try {
-                interceptFinalText(text);
                 if (unitySession.isOpen()) {
                     unitySession.sendMessage(new TextMessage(text));
                 }
             } catch (IOException e) {
                 log.error("[FastApiStream] Unity 전송 실패: sessionId={}, error={}", sessionId, e.getMessage());
             }
+            interceptFinalText(text);
         }
 
         private void interceptFinalText(String text) {

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/FastApiStreamSession.java
@@ -37,7 +37,7 @@ public class FastApiStreamSession {
 
     @FunctionalInterface
     public interface OnFinalText {
-        void accept(String query, String answer, String category, Boolean answerFound);
+        void accept(String query, String answer, String category, Boolean answerFound, Long responseTimeMs);
     }
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -72,7 +72,7 @@ public class FastApiStreamSession {
     ) {
         this.unitySession = unitySession;
         this.sessionId = sessionId;
-        this.onFinalText = onFinalText != null ? onFinalText : (q, a, c, f) -> {};
+        this.onFinalText = onFinalText != null ? onFinalText : (q, a, c, f, r) -> {};
 
         Request request = new Request.Builder().url(wsUrl).build();
         fastapiWs = okHttpClient.newWebSocket(request, new FastApiListener(startPayload));
@@ -152,10 +152,11 @@ public class FastApiStreamSession {
                 String answer = node.path("answer").asText(null);
                 String category = normalizeCategory(node.path("category").asText(null));
                 Boolean answerFound = parseAnswerFound(node);
+                Long responseTimeMs = parseResponseTimeMs(node);
                 if (query != null && answer != null) {
                     Thread.ofVirtual().start(() -> {
                         try {
-                            onFinalText.accept(query, answer, category, answerFound);
+                            onFinalText.accept(query, answer, category, answerFound, responseTimeMs);
                         } catch (Exception e) {
                             log.warn("[FastApiStream] final_text 후처리 실패: sessionId={}, error={}",
                                     sessionId, e.getMessage());
@@ -174,6 +175,13 @@ public class FastApiStreamSession {
         private Boolean parseAnswerFound(JsonNode node) {
             JsonNode answerFound = node.has("answerFound") ? node.get("answerFound") : node.get("answer_found");
             return answerFound == null || answerFound.isNull() ? null : answerFound.asBoolean();
+        }
+
+        private Long parseResponseTimeMs(JsonNode node) {
+            JsonNode responseTimeMs = node.has("responseTimeMs")
+                    ? node.get("responseTimeMs")
+                    : node.get("response_time_ms");
+            return responseTimeMs == null || responseTimeMs.isNull() ? null : responseTimeMs.asLong();
         }
 
         @Override

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
@@ -78,6 +78,12 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         DeviceDetails device = getDeviceDetails(session);
+        if (device == null || device.getSiteId() == null || device.getDeviceId() == null) {
+            log.warn("STT WS connection rejected: missing authenticated device context");
+            session.close(CloseStatus.POLICY_VIOLATION.withReason("device authentication is required"));
+            return;
+        }
+
         Map<String, String> params = parseQueryParams(session);
         String sessionId = params.get("sessionId");
         if (sessionId == null || sessionId.isBlank()) {
@@ -89,14 +95,20 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         log.info("STT WS 연결: deviceId={}, sessionId={}",
                 device != null ? device.getDeviceId() : "unknown", sessionId);
 
-        int siteId = parsePositiveIntOrDefault(params.get("siteId"), 1);
+        Long siteId = device.getSiteId();
         String languageCode = params.getOrDefault("languageCode", "ko-KR");
         int sampleRate = parsePositiveIntOrDefault(params.get("sampleRate"), 16000);
         boolean ttsStream = !"false".equalsIgnoreCase(params.get("ttsStream"));
 
-        String deviceId = device != null ? device.getDeviceId() : null;
+        String requestedSiteId = params.get("siteId");
+        if (requestedSiteId != null && !requestedSiteId.equals(String.valueOf(siteId))) {
+            log.warn("STT WS siteId query ignored: deviceId={}, requestedSiteId={}, authenticatedSiteId={}",
+                    device.getDeviceId(), requestedSiteId, siteId);
+        }
+
+        String deviceId = device.getDeviceId();
         KioskMascotDto mascot = fetchMascot(deviceId);
-        String startPayload = buildStartPayload(siteId, languageCode, sampleRate, ttsStream, mascot);
+        String startPayload = buildStartPayload(siteId, deviceId, languageCode, sampleRate, ttsStream, mascot);
 
         DeviceDetails deviceForCallback = device;
         FastApiStreamSession fastApiSession = new FastApiStreamSession(
@@ -164,14 +176,14 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     }
 
     /** FastAPI final_text 수신 후 Core에 대화 이력 저장. 실패해도 WS 흐름을 끊지 않음 */
-    private void saveWsChatHistory(String sessionId, DeviceDetails device, int siteId,
+    private void saveWsChatHistory(String sessionId, DeviceDetails device, Long siteId,
                                    String language, String query, String answer, String category) {
         try {
             String deviceId = device != null ? device.getDeviceId() : "unknown";
             coreChatClient.saveWsMessage(sessionId, WsChatSaveCommand.builder()
                     .sessionId(sessionId)
                     .deviceId(deviceId)
-                    .siteId((long) siteId)
+                    .siteId(siteId)
                     .question(query)
                     .answer(answer)
                     .language(language)
@@ -183,12 +195,13 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     }
 
     /** FastAPI WS 연결 직후 전송할 start 메시지 JSON 생성. 직렬화 실패 시 mascot 없이 최소 JSON 반환 */
-    private String buildStartPayload(int siteId, String languageCode, int sampleRate,
+    private String buildStartPayload(Long siteId, String deviceId, String languageCode, int sampleRate,
                                      boolean ttsStream, KioskMascotDto mascot) {
         try {
             Map<String, Object> start = new HashMap<>();
             start.put("type", "start");
             start.put("site_id", siteId);
+            start.put("device_id", deviceId);
             start.put("language_code", languageCode);
             start.put("sample_rate_hz", sampleRate);
             start.put("interim_results", true);
@@ -199,15 +212,26 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         } catch (Exception e) {
             log.warn("[SttWS] startPayload 직렬화 실패, mascot 없이 전송: {}", e.getMessage());
             return String.format(
-                    "{\"type\":\"start\",\"site_id\":%d,\"language_code\":\"%s\","
+                    "{\"type\":\"start\",\"site_id\":%d,\"device_id\":\"%s\",\"language_code\":\"%s\","
                             + "\"sample_rate_hz\":%d,\"interim_results\":true,"
                             + "\"tts_stream\":%b,\"realtime\":true}",
-                    siteId, languageCode, sampleRate, ttsStream
+                    siteId, escapeJson(deviceId), escapeJson(languageCode), sampleRate, ttsStream
             );
         }
     }
 
     /** 마스코트 DTO를 FastAPI가 기대하는 형태의 Map으로 변환. promptConfig 내 스타일 설정을 flat하게 꺼냄 */
+    // Fallback JSON escaping for manual start payload assembly.
+    private String escapeJson(String value) {
+        if (value == null) return "";
+        return value.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+
+    /** Builds the mascot payload shape expected by FastAPI. */
     private Map<String, Object> buildMascotPayload(KioskMascotDto mascot) {
         Map<String, Object> m = new HashMap<>();
         if (mascot == null) return m;

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
@@ -19,6 +19,7 @@ import org.springframework.web.socket.handler.AbstractWebSocketHandler;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -120,15 +121,14 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         String startPayload = buildStartPayload(
                 sessionId, siteId, deviceId, languageCode, sampleRate, ttsStream, mascot, dailyInfos, deviceLocation);
 
-        DeviceDetails deviceForCallback = device;
         FastApiStreamSession fastApiSession = new FastApiStreamSession(
                 okHttpClient,
                 fastApiConfig.getWsStreamUrl(),
                 session,
                 sessionId,
                 startPayload,
-                (query, answer, category, answerFound) -> saveWsChatHistory(
-                        sessionId, deviceForCallback, siteId, languageCode, query, answer, category, answerFound)
+                (query, answer, category, answerFound, responseTimeMs) -> saveWsChatHistory(
+                        sessionId, device, siteId, languageCode, query, answer, category, answerFound, responseTimeMs)
         );
         sessions.put(session.getId(), fastApiSession);
     }
@@ -189,7 +189,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     private List<DailyInfoDto> fetchDailyInfos(Long siteId) {
         if (siteId == null) return List.of();
         try {
-            return coreDailyInfoClient.getDailyInfos(siteId);
+            return coreDailyInfoClient.getDailyInfos(siteId, LocalDate.now());
         } catch (Exception e) {
             log.warn("[SttWS] dailyInfos 조회 실패 (빈 context 사용): siteId={}, error={}", siteId, e.getMessage());
             return List.of();
@@ -198,9 +198,10 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
 
     /** FastAPI final_text 수신 후 Core에 대화 이력 저장. 실패해도 WS 흐름을 끊지 않음 */
     private void saveWsChatHistory(String sessionId, DeviceDetails device, Long siteId,
-                                   String language, String query, String answer, String category, Boolean answerFound) {
+                                   String language, String query, String answer, String category,
+                                   Boolean answerFound, Long responseTimeMs) {
         try {
-            String deviceId = device != null ? device.getDeviceId() : "unknown";
+            String deviceId = device.getDeviceId();
             String normalizedLanguage = normalizeLanguage(language);
             coreChatClient.saveWsMessage(sessionId, WsChatSaveCommand.builder()
                     .sessionId(sessionId)
@@ -211,6 +212,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
                     .language(normalizedLanguage)
                     .category(category)
                     .answerFound(answerFound)
+                    .responseTimeMs(responseTimeMs)
                     .build());
         } catch (Exception e) {
             log.warn("[SttWS] 채팅 이력 저장 실패 (무시): sessionId={}, error={}", sessionId, e.getMessage());
@@ -246,7 +248,8 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
             return String.format(
                     "{\"type\":\"start\",\"sessionId\":\"%s\",\"siteId\":%d,\"deviceId\":\"%s\",\"language\":\"%s\","
                             + "\"sampleRateHz\":%d,\"interimResults\":true,"
-                            + "\"ttsStream\":%b,\"realtime\":true}",
+                            + "\"ttsStream\":%b,\"realtime\":true,"
+                            + "\"context\":{\"dailyInfos\":[]}}",
                     escapeJson(sessionId), siteId, escapeJson(deviceId), escapeJson(languageCode), sampleRate, ttsStream
             );
         }

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
@@ -3,8 +3,8 @@ package com.guideon.kiosk.domain.stt.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.guideon.core.dto.chat.WsChatSaveCommand;
 import com.guideon.core.dto.kiosk.KioskMascotDto;
+import com.guideon.kiosk.client.CoreChatClient;
 import com.guideon.kiosk.client.CoreKioskClient;
-import com.guideon.kiosk.client.CoreWsChatClient;
 import com.guideon.kiosk.global.config.FastApiConfig;
 import com.guideon.kiosk.global.security.DeviceDetails;
 import com.guideon.kiosk.global.security.DeviceTokenHandshakeInterceptor;
@@ -56,7 +56,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     private final FastApiConfig fastApiConfig;
     private final OkHttpClient okHttpClient;
     private final CoreKioskClient coreKioskClient;
-    private final CoreWsChatClient coreWsChatClient;
+    private final CoreChatClient coreChatClient;
 
     /** Spring WS session.getId() → FastApiStreamSession */
     private final ConcurrentHashMap<String, FastApiStreamSession> sessions = new ConcurrentHashMap<>();
@@ -66,13 +66,13 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
             FastApiConfig fastApiConfig,
             @Qualifier("fastapiOkHttpClient") OkHttpClient okHttpClient,
             CoreKioskClient coreKioskClient,
-            CoreWsChatClient coreWsChatClient
+            CoreChatClient coreChatClient
     ) {
         this.objectMapper = objectMapper;
         this.fastApiConfig = fastApiConfig;
         this.okHttpClient = okHttpClient;
         this.coreKioskClient = coreKioskClient;
-        this.coreWsChatClient = coreWsChatClient;
+        this.coreChatClient = coreChatClient;
     }
 
     @Override
@@ -166,7 +166,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
                                    String language, String query, String answer) {
         try {
             String deviceId = device != null ? device.getDeviceId() : "unknown";
-            coreWsChatClient.saveWsMessage(sessionId, WsChatSaveCommand.builder()
+            coreChatClient.saveWsMessage(sessionId, WsChatSaveCommand.builder()
                     .sessionId(sessionId)
                     .deviceId(deviceId)
                     .siteId((long) siteId)

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
@@ -127,7 +127,8 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
                 session,
                 sessionId,
                 startPayload,
-                (query, answer, category) -> saveWsChatHistory(sessionId, deviceForCallback, siteId, languageCode, query, answer, category)
+                (query, answer, category, answerFound) -> saveWsChatHistory(
+                        sessionId, deviceForCallback, siteId, languageCode, query, answer, category, answerFound)
         );
         sessions.put(session.getId(), fastApiSession);
     }
@@ -197,7 +198,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
 
     /** FastAPI final_text 수신 후 Core에 대화 이력 저장. 실패해도 WS 흐름을 끊지 않음 */
     private void saveWsChatHistory(String sessionId, DeviceDetails device, Long siteId,
-                                   String language, String query, String answer, String category) {
+                                   String language, String query, String answer, String category, Boolean answerFound) {
         try {
             String deviceId = device != null ? device.getDeviceId() : "unknown";
             String normalizedLanguage = normalizeLanguage(language);
@@ -209,6 +210,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
                     .answer(answer)
                     .language(normalizedLanguage)
                     .category(category)
+                    .answerFound(answerFound)
                     .build());
         } catch (Exception e) {
             log.warn("[SttWS] 채팅 이력 저장 실패 (무시): sessionId={}, error={}", sessionId, e.getMessage());

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
@@ -1,6 +1,10 @@
 package com.guideon.kiosk.domain.stt.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guideon.core.dto.chat.WsChatSaveCommand;
+import com.guideon.core.dto.mascot.MascotDto;
+import com.guideon.kiosk.client.CoreMascotClient;
+import com.guideon.kiosk.client.CoreWsChatClient;
 import com.guideon.kiosk.global.config.FastApiConfig;
 import com.guideon.kiosk.global.security.DeviceDetails;
 import com.guideon.kiosk.global.security.DeviceTokenHandshakeInterceptor;
@@ -51,6 +55,8 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     private final ObjectMapper objectMapper;
     private final FastApiConfig fastApiConfig;
     private final OkHttpClient okHttpClient;
+    private final CoreMascotClient coreMascotClient;
+    private final CoreWsChatClient coreWsChatClient;
 
     /** Spring WS session.getId() → FastApiStreamSession */
     private final ConcurrentHashMap<String, FastApiStreamSession> sessions = new ConcurrentHashMap<>();
@@ -58,11 +64,15 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     public SttWebSocketHandler(
             ObjectMapper objectMapper,
             FastApiConfig fastApiConfig,
-            @Qualifier("fastapiOkHttpClient") OkHttpClient okHttpClient
+            @Qualifier("fastapiOkHttpClient") OkHttpClient okHttpClient,
+            CoreMascotClient coreMascotClient,
+            CoreWsChatClient coreWsChatClient
     ) {
         this.objectMapper = objectMapper;
         this.fastApiConfig = fastApiConfig;
         this.okHttpClient = okHttpClient;
+        this.coreMascotClient = coreMascotClient;
+        this.coreWsChatClient = coreWsChatClient;
     }
 
     @Override
@@ -84,14 +94,17 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         int sampleRate = parsePositiveIntOrDefault(params.get("sampleRate"), 16000);
         boolean ttsStream = !"false".equalsIgnoreCase(params.get("ttsStream"));
 
-        String startPayload = buildStartPayload(siteId, languageCode, sampleRate, ttsStream);
+        MascotDto mascot = fetchMascot((long) siteId);
+        String startPayload = buildStartPayload(siteId, languageCode, sampleRate, ttsStream, mascot);
 
+        DeviceDetails deviceForCallback = device;
         FastApiStreamSession fastApiSession = new FastApiStreamSession(
                 okHttpClient,
                 fastApiConfig.getWsStreamUrl(),
                 session,
                 sessionId,
-                startPayload
+                startPayload,
+                (query, answer) -> saveWsChatHistory(sessionId, deviceForCallback, siteId, languageCode, query, answer)
         );
         sessions.put(session.getId(), fastApiSession);
     }
@@ -138,7 +151,34 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
-    private String buildStartPayload(int siteId, String languageCode, int sampleRate, boolean ttsStream) {
+    private MascotDto fetchMascot(Long siteId) {
+        try {
+            return coreMascotClient.getMascot(siteId);
+        } catch (Exception e) {
+            log.warn("[SttWS] mascot 조회 실패 (기본 프롬프트 사용): siteId={}, error={}", siteId, e.getMessage());
+            return null;
+        }
+    }
+
+    private void saveWsChatHistory(String sessionId, DeviceDetails device, int siteId,
+                                   String language, String query, String answer) {
+        try {
+            String deviceId = device != null ? device.getDeviceId() : "unknown";
+            coreWsChatClient.saveWsMessage(sessionId, WsChatSaveCommand.builder()
+                    .sessionId(sessionId)
+                    .deviceId(deviceId)
+                    .siteId((long) siteId)
+                    .question(query)
+                    .answer(answer)
+                    .language(language)
+                    .build());
+        } catch (Exception e) {
+            log.warn("[SttWS] 채팅 이력 저장 실패 (무시): sessionId={}, error={}", sessionId, e.getMessage());
+        }
+    }
+
+    private String buildStartPayload(int siteId, String languageCode, int sampleRate,
+                                     boolean ttsStream, MascotDto mascot) {
         try {
             Map<String, Object> start = new HashMap<>();
             start.put("type", "start");
@@ -148,8 +188,10 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
             start.put("interim_results", true);
             start.put("tts_stream", ttsStream);
             start.put("realtime", true);
+            start.put("mascot", buildMascotPayload(mascot));
             return objectMapper.writeValueAsString(start);
         } catch (Exception e) {
+            log.warn("[SttWS] startPayload 직렬화 실패, mascot 없이 전송: {}", e.getMessage());
             return String.format(
                     "{\"type\":\"start\",\"site_id\":%d,\"language_code\":\"%s\","
                             + "\"sample_rate_hz\":%d,\"interim_results\":true,"
@@ -157,6 +199,26 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
                     siteId, languageCode, sampleRate, ttsStream
             );
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> buildMascotPayload(MascotDto mascot) {
+        Map<String, Object> m = new HashMap<>();
+        if (mascot == null) return m;
+
+        m.put("system_prompt", mascot.getSystemPrompt() != null ? mascot.getSystemPrompt() : "");
+        m.put("mascot_name", mascot.getName() != null ? mascot.getName() : "");
+        m.put("mascot_greeting", mascot.getGreetingMsg() != null ? mascot.getGreetingMsg() : "");
+
+        Map<String, Object> config = mascot.getPromptConfig();
+        if (config != null) {
+            m.put("mascot_base_persona",    config.getOrDefault("mascot_base_persona", ""));
+            m.put("mascot_smalltalk_style", config.getOrDefault("mascot_smalltalk_style", ""));
+            m.put("mascot_struct_db_style", config.getOrDefault("mascot_struct_db_style", ""));
+            m.put("mascot_RAG_style",       config.getOrDefault("mascot_RAG_style", ""));
+            m.put("mascot_event_style",     config.getOrDefault("mascot_event_style", ""));
+        }
+        return m;
     }
 
     private Map<String, String> parseQueryParams(WebSocketSession session) {

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
@@ -2,8 +2,8 @@ package com.guideon.kiosk.domain.stt.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.guideon.core.dto.chat.WsChatSaveCommand;
-import com.guideon.core.dto.mascot.MascotDto;
-import com.guideon.kiosk.client.CoreMascotClient;
+import com.guideon.core.dto.kiosk.KioskMascotDto;
+import com.guideon.kiosk.client.CoreKioskClient;
 import com.guideon.kiosk.client.CoreWsChatClient;
 import com.guideon.kiosk.global.config.FastApiConfig;
 import com.guideon.kiosk.global.security.DeviceDetails;
@@ -55,7 +55,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     private final ObjectMapper objectMapper;
     private final FastApiConfig fastApiConfig;
     private final OkHttpClient okHttpClient;
-    private final CoreMascotClient coreMascotClient;
+    private final CoreKioskClient coreKioskClient;
     private final CoreWsChatClient coreWsChatClient;
 
     /** Spring WS session.getId() → FastApiStreamSession */
@@ -65,13 +65,13 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
             ObjectMapper objectMapper,
             FastApiConfig fastApiConfig,
             @Qualifier("fastapiOkHttpClient") OkHttpClient okHttpClient,
-            CoreMascotClient coreMascotClient,
+            CoreKioskClient coreKioskClient,
             CoreWsChatClient coreWsChatClient
     ) {
         this.objectMapper = objectMapper;
         this.fastApiConfig = fastApiConfig;
         this.okHttpClient = okHttpClient;
-        this.coreMascotClient = coreMascotClient;
+        this.coreKioskClient = coreKioskClient;
         this.coreWsChatClient = coreWsChatClient;
     }
 
@@ -94,7 +94,8 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         int sampleRate = parsePositiveIntOrDefault(params.get("sampleRate"), 16000);
         boolean ttsStream = !"false".equalsIgnoreCase(params.get("ttsStream"));
 
-        MascotDto mascot = fetchMascot((long) siteId);
+        String deviceId = device != null ? device.getDeviceId() : null;
+        KioskMascotDto mascot = fetchMascot(deviceId);
         String startPayload = buildStartPayload(siteId, languageCode, sampleRate, ttsStream, mascot);
 
         DeviceDetails deviceForCallback = device;
@@ -151,11 +152,12 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
-    private MascotDto fetchMascot(Long siteId) {
+    private KioskMascotDto fetchMascot(String deviceId) {
+        if (deviceId == null) return null;
         try {
-            return coreMascotClient.getMascot(siteId);
+            return coreKioskClient.getMascot(deviceId);
         } catch (Exception e) {
-            log.warn("[SttWS] mascot 조회 실패 (기본 프롬프트 사용): siteId={}, error={}", siteId, e.getMessage());
+            log.warn("[SttWS] mascot 조회 실패 (기본 프롬프트 사용): deviceId={}, error={}", deviceId, e.getMessage());
             return null;
         }
     }
@@ -178,7 +180,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     }
 
     private String buildStartPayload(int siteId, String languageCode, int sampleRate,
-                                     boolean ttsStream, MascotDto mascot) {
+                                     boolean ttsStream, KioskMascotDto mascot) {
         try {
             Map<String, Object> start = new HashMap<>();
             start.put("type", "start");
@@ -201,8 +203,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> buildMascotPayload(MascotDto mascot) {
+    private Map<String, Object> buildMascotPayload(KioskMascotDto mascot) {
         Map<String, Object> m = new HashMap<>();
         if (mascot == null) return m;
 

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
@@ -1,9 +1,11 @@
 package com.guideon.kiosk.domain.stt.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guideon.core.dto.dailyinfo.DailyInfoDto;
 import com.guideon.core.dto.chat.WsChatSaveCommand;
 import com.guideon.core.dto.kiosk.KioskMascotDto;
 import com.guideon.kiosk.client.CoreChatClient;
+import com.guideon.kiosk.client.CoreDailyInfoClient;
 import com.guideon.kiosk.client.CoreKioskClient;
 import com.guideon.kiosk.global.config.FastApiConfig;
 import com.guideon.kiosk.global.security.DeviceDetails;
@@ -18,6 +20,8 @@ import org.springframework.web.socket.handler.AbstractWebSocketHandler;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -37,7 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * - {"type":"stt_interim", "text":"...", "language_code":"...", "confidence":0.9}
  * - {"type":"stt_final",   "text":"...", "language_code":"...", "confidence":0.9}
  * - {"type":"tts_chunk",   "seq":0, "text":"...", "audio_b64":"...", "is_final":true}
- * - {"type":"final_text",  "query":"...", "answer":"..."}
+ * - {"type":"final_text",  "query":"...", "answer":"...", "category":"..."}
  * - {"type":"done"}
  * - {"type":"error",   "code":"...", "message":"..."}
  *
@@ -57,6 +61,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     private final OkHttpClient okHttpClient;
     private final CoreKioskClient coreKioskClient;
     private final CoreChatClient coreChatClient;
+    private final CoreDailyInfoClient coreDailyInfoClient;
 
     /** Spring WS session.getId() → FastApiStreamSession */
     private final ConcurrentHashMap<String, FastApiStreamSession> sessions = new ConcurrentHashMap<>();
@@ -66,13 +71,15 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
             FastApiConfig fastApiConfig,
             @Qualifier("fastapiOkHttpClient") OkHttpClient okHttpClient,
             CoreKioskClient coreKioskClient,
-            CoreChatClient coreChatClient
+            CoreChatClient coreChatClient,
+            CoreDailyInfoClient coreDailyInfoClient
     ) {
         this.objectMapper = objectMapper;
         this.fastApiConfig = fastApiConfig;
         this.okHttpClient = okHttpClient;
         this.coreKioskClient = coreKioskClient;
         this.coreChatClient = coreChatClient;
+        this.coreDailyInfoClient = coreDailyInfoClient;
     }
 
     @Override
@@ -93,7 +100,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         }
 
         log.info("STT WS 연결: deviceId={}, sessionId={}",
-                device != null ? device.getDeviceId() : "unknown", sessionId);
+                device.getDeviceId(), sessionId);
 
         Long siteId = device.getSiteId();
         String languageCode = params.getOrDefault("languageCode", "ko-KR");
@@ -108,7 +115,10 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
 
         String deviceId = device.getDeviceId();
         KioskMascotDto mascot = fetchMascot(deviceId);
-        String startPayload = buildStartPayload(siteId, deviceId, languageCode, sampleRate, ttsStream, mascot);
+        List<DailyInfoDto> dailyInfos = fetchDailyInfos(siteId);
+        Map<String, Object> deviceLocation = buildDeviceLocationPayload(device);
+        String startPayload = buildStartPayload(
+                sessionId, siteId, deviceId, languageCode, sampleRate, ttsStream, mascot, dailyInfos, deviceLocation);
 
         DeviceDetails deviceForCallback = device;
         FastApiStreamSession fastApiSession = new FastApiStreamSession(
@@ -175,18 +185,29 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         }
     }
 
+    private List<DailyInfoDto> fetchDailyInfos(Long siteId) {
+        if (siteId == null) return List.of();
+        try {
+            return coreDailyInfoClient.getDailyInfos(siteId);
+        } catch (Exception e) {
+            log.warn("[SttWS] dailyInfos 조회 실패 (빈 context 사용): siteId={}, error={}", siteId, e.getMessage());
+            return List.of();
+        }
+    }
+
     /** FastAPI final_text 수신 후 Core에 대화 이력 저장. 실패해도 WS 흐름을 끊지 않음 */
     private void saveWsChatHistory(String sessionId, DeviceDetails device, Long siteId,
                                    String language, String query, String answer, String category) {
         try {
             String deviceId = device != null ? device.getDeviceId() : "unknown";
+            String normalizedLanguage = normalizeLanguage(language);
             coreChatClient.saveWsMessage(sessionId, WsChatSaveCommand.builder()
                     .sessionId(sessionId)
                     .deviceId(deviceId)
                     .siteId(siteId)
                     .question(query)
                     .answer(answer)
-                    .language(language)
+                    .language(normalizedLanguage)
                     .category(category)
                     .build());
         } catch (Exception e) {
@@ -195,32 +216,70 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
     }
 
     /** FastAPI WS 연결 직후 전송할 start 메시지 JSON 생성. 직렬화 실패 시 mascot 없이 최소 JSON 반환 */
-    private String buildStartPayload(Long siteId, String deviceId, String languageCode, int sampleRate,
-                                     boolean ttsStream, KioskMascotDto mascot) {
+    private String buildStartPayload(String sessionId, Long siteId, String deviceId, String languageCode, int sampleRate,
+                                     boolean ttsStream, KioskMascotDto mascot, List<DailyInfoDto> dailyInfos,
+                                     Map<String, Object> deviceLocation) {
         try {
             Map<String, Object> start = new HashMap<>();
             start.put("type", "start");
-            start.put("site_id", siteId);
-            start.put("device_id", deviceId);
-            start.put("language_code", languageCode);
-            start.put("sample_rate_hz", sampleRate);
-            start.put("interim_results", true);
-            start.put("tts_stream", ttsStream);
+            start.put("sessionId", sessionId);
+            start.put("siteId", siteId);
+            start.put("deviceId", deviceId);
+            start.put("language", languageCode);
+            start.put("systemPrompt", mascot != null ? mascot.getSystemPrompt() : null);
+            start.put("name", mascot != null ? mascot.getName() : null);
+            start.put("greetingMsg", mascot != null ? mascot.getGreetingMsg() : null);
+            start.put("promptConfig", mascot != null && mascot.getPromptConfig() != null ? mascot.getPromptConfig() : Map.of());
+            if (deviceLocation != null) {
+                start.put("deviceLocation", deviceLocation);
+            }
+            start.put("sampleRateHz", sampleRate);
+            start.put("interimResults", true);
+            start.put("ttsStream", ttsStream);
             start.put("realtime", true);
-            start.put("mascot", buildMascotPayload(mascot));
+            start.put("context", buildContextPayload(dailyInfos));
             return objectMapper.writeValueAsString(start);
         } catch (Exception e) {
             log.warn("[SttWS] startPayload 직렬화 실패, mascot 없이 전송: {}", e.getMessage());
             return String.format(
-                    "{\"type\":\"start\",\"site_id\":%d,\"device_id\":\"%s\",\"language_code\":\"%s\","
-                            + "\"sample_rate_hz\":%d,\"interim_results\":true,"
-                            + "\"tts_stream\":%b,\"realtime\":true}",
-                    siteId, escapeJson(deviceId), escapeJson(languageCode), sampleRate, ttsStream
+                    "{\"type\":\"start\",\"sessionId\":\"%s\",\"siteId\":%d,\"deviceId\":\"%s\",\"language\":\"%s\","
+                            + "\"sampleRateHz\":%d,\"interimResults\":true,"
+                            + "\"ttsStream\":%b,\"realtime\":true}",
+                    escapeJson(sessionId), siteId, escapeJson(deviceId), escapeJson(languageCode), sampleRate, ttsStream
             );
         }
     }
 
-    /** 마스코트 DTO를 FastAPI가 기대하는 형태의 Map으로 변환. promptConfig 내 스타일 설정을 flat하게 꺼냄 */
+    /** WebSocket start 메시지에 실을 QaRequest context payload 생성 */
+    private Map<String, Object> buildContextPayload(List<DailyInfoDto> dailyInfos) {
+        Map<String, Object> context = new HashMap<>();
+        context.put("dailyInfos", buildDailyInfosPayload(dailyInfos));
+        return context;
+    }
+
+    private List<Map<String, Object>> buildDailyInfosPayload(List<DailyInfoDto> dailyInfos) {
+        if (dailyInfos == null || dailyInfos.isEmpty()) return List.of();
+        return dailyInfos.stream()
+                .map(di -> {
+                    Map<String, Object> item = new HashMap<>();
+                    item.put("placeName", di.getPlaceName());
+                    item.put("infoType", di.getInfoType());
+                    item.put("content", di.getContent());
+                    return item;
+                })
+                .toList();
+    }
+
+    private Map<String, Object> buildDeviceLocationPayload(DeviceDetails device) {
+        if (device == null || device.getLatitude() == null || device.getLongitude() == null) {
+            return null;
+        }
+        Map<String, Object> location = new HashMap<>();
+        location.put("latitude", device.getLatitude());
+        location.put("longitude", device.getLongitude());
+        return location;
+    }
+
     // Fallback JSON escaping for manual start payload assembly.
     private String escapeJson(String value) {
         if (value == null) return "";
@@ -231,24 +290,12 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
                 .replace("\t", "\\t");
     }
 
-    /** Builds the mascot payload shape expected by FastAPI. */
-    private Map<String, Object> buildMascotPayload(KioskMascotDto mascot) {
-        Map<String, Object> m = new HashMap<>();
-        if (mascot == null) return m;
-
-        m.put("system_prompt", mascot.getSystemPrompt() != null ? mascot.getSystemPrompt() : "");
-        m.put("mascot_name", mascot.getName() != null ? mascot.getName() : "");
-        m.put("mascot_greeting", mascot.getGreetingMsg() != null ? mascot.getGreetingMsg() : "");
-
-        Map<String, Object> config = mascot.getPromptConfig();
-        if (config != null) {
-            m.put("mascot_base_persona",    config.getOrDefault("mascot_base_persona", ""));
-            m.put("mascot_smalltalk_style", config.getOrDefault("mascot_smalltalk_style", ""));
-            m.put("mascot_struct_db_style", config.getOrDefault("mascot_struct_db_style", ""));
-            m.put("mascot_RAG_style",       config.getOrDefault("mascot_RAG_style", ""));
-            m.put("mascot_event_style",     config.getOrDefault("mascot_event_style", ""));
+    private String normalizeLanguage(String language) {
+        if (language == null || language.isBlank()) {
+            return "ko";
         }
-        return m;
+        String normalized = language.split("-", 2)[0].trim().toLowerCase(Locale.ROOT);
+        return normalized.isBlank() ? "ko" : normalized;
     }
 
     /** WS URI 쿼리 파라미터(?key=value&...)를 Map으로 파싱. URL 인코딩된 값도 디코딩 */

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
@@ -105,7 +105,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
                 session,
                 sessionId,
                 startPayload,
-                (query, answer) -> saveWsChatHistory(sessionId, deviceForCallback, siteId, languageCode, query, answer)
+                (query, answer, category) -> saveWsChatHistory(sessionId, deviceForCallback, siteId, languageCode, query, answer, category)
         );
         sessions.put(session.getId(), fastApiSession);
     }
@@ -152,6 +152,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
 
     // ── helpers ─────────────────────────────────────────────────────────────
 
+    /** deviceId로 Core에서 마스코트 정보 조회. 실패 시 null 반환 → FastAPI 기본 프롬프트 사용 */
     private KioskMascotDto fetchMascot(String deviceId) {
         if (deviceId == null) return null;
         try {
@@ -162,8 +163,9 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         }
     }
 
+    /** FastAPI final_text 수신 후 Core에 대화 이력 저장. 실패해도 WS 흐름을 끊지 않음 */
     private void saveWsChatHistory(String sessionId, DeviceDetails device, int siteId,
-                                   String language, String query, String answer) {
+                                   String language, String query, String answer, String category) {
         try {
             String deviceId = device != null ? device.getDeviceId() : "unknown";
             coreChatClient.saveWsMessage(sessionId, WsChatSaveCommand.builder()
@@ -173,12 +175,14 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
                     .question(query)
                     .answer(answer)
                     .language(language)
+                    .category(category)
                     .build());
         } catch (Exception e) {
             log.warn("[SttWS] 채팅 이력 저장 실패 (무시): sessionId={}, error={}", sessionId, e.getMessage());
         }
     }
 
+    /** FastAPI WS 연결 직후 전송할 start 메시지 JSON 생성. 직렬화 실패 시 mascot 없이 최소 JSON 반환 */
     private String buildStartPayload(int siteId, String languageCode, int sampleRate,
                                      boolean ttsStream, KioskMascotDto mascot) {
         try {
@@ -203,6 +207,7 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         }
     }
 
+    /** 마스코트 DTO를 FastAPI가 기대하는 형태의 Map으로 변환. promptConfig 내 스타일 설정을 flat하게 꺼냄 */
     private Map<String, Object> buildMascotPayload(KioskMascotDto mascot) {
         Map<String, Object> m = new HashMap<>();
         if (mascot == null) return m;
@@ -222,9 +227,11 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         return m;
     }
 
+    /** WS URI 쿼리 파라미터(?key=value&...)를 Map으로 파싱. URL 인코딩된 값도 디코딩 */
     private Map<String, String> parseQueryParams(WebSocketSession session) {
         Map<String, String> params = new HashMap<>();
-        String query = session.getUri() != null ? session.getUri().getRawQuery() : null;
+        java.net.URI uri = session.getUri();
+        String query = uri != null ? uri.getRawQuery() : null;
         if (query == null) return params;
         for (String pair : query.split("&")) {
             String[] kv = pair.split("=", 2);
@@ -238,11 +245,13 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
         return params;
     }
 
+    /** 핸드셰이크 인터셉터가 JWT 인증 후 세션 attributes에 저장해 둔 DeviceDetails 조회 */
     private DeviceDetails getDeviceDetails(WebSocketSession session) {
         return (DeviceDetails) session.getAttributes()
                 .get(DeviceTokenHandshakeInterceptor.DEVICE_DETAILS_ATTR);
     }
 
+    /** 문자열을 양의 정수로 파싱. 파싱 실패 또는 0 이하면 defaultValue 반환 */
     private int parsePositiveIntOrDefault(String value, int defaultValue) {
         if (value == null) return defaultValue;
         try {

--- a/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
+++ b/guideon-kiosk-bff/src/main/java/com/guideon/kiosk/domain/stt/handler/SttWebSocketHandler.java
@@ -104,7 +104,10 @@ public class SttWebSocketHandler extends AbstractWebSocketHandler {
                 device.getDeviceId(), sessionId);
 
         Long siteId = device.getSiteId();
-        String languageCode = params.getOrDefault("languageCode", "ko-KR");
+        String requestedLanguageCode = params.get("languageCode");
+        String languageCode = (requestedLanguageCode == null || requestedLanguageCode.isBlank())
+                ? "ko-KR"
+                : requestedLanguageCode.trim();
         int sampleRate = parsePositiveIntOrDefault(params.get("sampleRate"), 16000);
         boolean ttsStream = !"false".equalsIgnoreCase(params.get("ttsStream"));
 


### PR DESCRIPTION
## Summary
- #133
- #136 

## Tasks
- [x] WebSocket STT 연결 시 `siteId`를 클라이언트 값이 아니라 Device Token 인증 정보 기준으로 사용
- [x] FastAPI start payload를 REST 채팅 `QaRequest` 구조와 맞춤
  - `sessionId`, `siteId`, `deviceId`, `language`
  - `systemPrompt`, `name`, `greetingMsg`, `promptConfig`
  - `deviceLocation`, `context.dailyInfos`
- [x] WebSocket 경로에서도 Core에서 마스코트 정보와 dailyInfos 조회 후 FastAPI에 전달
- [x] STT/TTS 제어 필드명을 camelCase로 정리
  - `sampleRateHz`, `interimResults`, `ttsStream`
- [x] FastAPI `final_text`를 Unity에 먼저 전달한 뒤 Core에 채팅 이력 저장
- [x] WS 채팅 저장 시 `language`를 `ko-KR` → `ko` 형태로 정규화
- [x] `category`를 함께 저장하도록 연결

## To Reviewer
-### Unity WebSocket STT/TTS 연동 안내
Unity는 FastAPI에 직접 연결하지 않고, Kiosk BFF WebSocket에만 연결하면 됩니다.

### 연결 URL
```text
ws://{KIOSK_BFF_HOST}:8082/ws/v1/kiosk/stt?sessionId={sessionId}&languageCode=ko-KR
```

## Unity → BFF로 보내는 메시지
1. 음성 입력 중에는 PCM binary chunk를 WebSocket binary frame으로 전송
2. 발화가 끝나면 text frame으로 stop 메시지를 보냅니다.

## Screenshot
<img src="" width="50%" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * WebSocket 기반 채팅 이력 자동 저장 추가 (STT 완료 시 서버에 영구 저장)
  * 마스코트에 시스템 프롬프트 및 프롬프트 구성 옵션 추가
  * 사이트별 일일 정보 조회 API 추가
  * STT 스트림의 최종 텍스트 감지 및 콜백 처리 기능 구현

* **버그 수정/안정성**
  * STT WebSocket 연결에 인증 필수화 및 파라미터 불일치 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->