### PR TITLE
fix : FastAPI storage_url 허용 도메인 추가

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -125,6 +125,7 @@ services:
       LANGSMITH_PROJECT: ${LANGSMITH_PROJECT:-guideon_ai}
       RAG_VERSION: ${RAG_VERSION:-v2}
       CORE_BASE_URL: http://core:8080
+      ALLOWED_STORAGE_HOSTS: ${DOMAIN}
     volumes:
       - ./google_key.json:/app/google_key.json:ro
     depends_on:


### PR DESCRIPTION
## Summary
- FastAPI  storage_url 허용 도메인 추가
-

## Tasks
- [x] 서버에서 문서 업로드가 막혀 docker-compose.prod 에 허용 도메인 추가했습니다.

## To Reviewer
- 

## Screenshot
<img src="" width="50%" />