### PR TITLE
Fix/document loading

### DIFF
--- a/guideon-core/src/main/java/com/guideon/core/client/FastApiDocumentService.java
+++ b/guideon-core/src/main/java/com/guideon/core/client/FastApiDocumentService.java
@@ -1,6 +1,8 @@
 package com.guideon.core.client;
 
 import com.guideon.core.dto.document.ProcessDocumentCommand;
+import com.guideon.core.dto.document.UpdateDocumentStatusCommand;
+import com.guideon.core.service.DocumentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -9,7 +11,7 @@ import org.springframework.stereotype.Service;
 /**
  * FastAPI 비동기 호출 래퍼
  * Feign 인터페이스는 @Async를 직접 붙일 수 없어 별도 서비스로 분리
- * 실패 시 로그만 남기고 문서는 PENDING 유지 → 관리자가 재처리 가능
+ * 실패 시 상태를 FAILED로 업데이트하여 무한 PENDING 방지
  */
 @Slf4j
 @Service
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class FastApiDocumentService {
 
     private final FastApiDocumentClient fastApiDocumentClient;
+    private final DocumentService documentService;
 
     @Async("fastApiTaskExecutor")
     public void processDocument(ProcessDocumentCommand command) {
@@ -24,8 +27,20 @@ public class FastApiDocumentService {
             fastApiDocumentClient.processDocument(command);
             log.info("FastAPI 처리 요청 완료: docId={}", command.getDocId());
         } catch (Exception e) {
-            log.error("FastAPI 처리 요청 실패 (문서는 PENDING 유지): docId={}, error={}",
+            log.error("FastAPI 처리 요청 실패 → FAILED 처리: docId={}, error={}",
                     command.getDocId(), e.getMessage());
+            try {
+                documentService.updateDocumentStatus(
+                        command.getSiteId(),
+                        command.getDocId(),
+                        UpdateDocumentStatusCommand.builder()
+                                .status("FAILED")
+                                .failedReason("FastAPI 연결 실패: " + e.getMessage())
+                                .build()
+                );
+            } catch (Exception ex) {
+                log.error("FAILED 상태 업데이트도 실패: docId={}, error={}", command.getDocId(), ex.getMessage());
+            }
         }
     }
 }

--- a/guideon-core/src/main/java/com/guideon/core/dto/document/UpdateDocumentStatusCommand.java
+++ b/guideon-core/src/main/java/com/guideon/core/dto/document/UpdateDocumentStatusCommand.java
@@ -3,6 +3,8 @@ package com.guideon.core.dto.document;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.StringUtils;
@@ -13,7 +15,9 @@ import org.springframework.util.StringUtils;
  * FAILED 시 failed_reason 필수
  */
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class UpdateDocumentStatusCommand {
 
     @NotBlank(message = "status는 필수입니다.")


### PR DESCRIPTION
## Summary
- #172 
-

## Tasks
- [x] 문서 업로드 시 fastAPI 연동 실패 할 때 fail 반환
- [ ] 

## To Reviewer
- 

## Screenshot
<img src="" width="50%" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * FastAPI 연결 실패 시 문서 상태를 적절하게 '실패' 상태로 업데이트하고 실패 사유를 기록하도록 개선했습니다. 실패 상태 업데이트 중 오류 발생 시에도 로그가 남도록 처리했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-Guideon/guideon-backend/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->