### PR TITLE
Feat/mascot animation

### DIFF
--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/dto/GenerationStatusResponse.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/dto/GenerationStatusResponse.java
@@ -1,10 +1,12 @@
 package com.guideon.guideonbackend.domain.mascot.dto;
 
 import com.guideon.core.domain.mascot.entity.MascotGeneration;
+import com.guideon.guideonbackend.domain.mascot.service.MascotMotion;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Getter
 @Builder
@@ -16,6 +18,9 @@ public class GenerationStatusResponse {
     private String modelStatus;
     private String rigTaskId;
     private String rigStatus;
+    private String retargetStatus;
+    private String animModelUrl;
+    private Map<String, String> animClips;
     private String resultModelUrl;
     private String failedReason;
     private boolean completed;
@@ -31,6 +36,9 @@ public class GenerationStatusResponse {
                 .modelStatus(gen.getModelStatusValue())
                 .rigTaskId(gen.getRigTaskId())
                 .rigStatus(gen.getRigStatusValue())
+                .retargetStatus(gen.getRetargetStatusValue())
+                .animModelUrl(gen.getAnimModelUrl())
+                .animClips(MascotMotion.clipMap())
                 .resultModelUrl(gen.getResultModelUrl())
                 .failedReason(gen.getFailedReason())
                 .completed(gen.isFullyCompleted())

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationPersistService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationPersistService.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
+
 /**
  * MascotGeneration DB 저장/업데이트 전담.
  * 외부 API 호출 없이 트랜잭션 범위를 최소화.
@@ -67,7 +69,7 @@ public class MascotGenerationPersistService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MASCOT_GENERATION_NOT_FOUND));
         gen.completeRigging(modelUrl);
 
-        // tb_mascot에 model_url 자동 업데이트
+        // tb_mascot에 base model_url 자동 업데이트
         mascotRepository.findBySite_SiteId(siteId).ifPresentOrElse(
                 mascot -> {
                     mascot.updateModelUrl(modelUrl, "glb", gen);
@@ -84,6 +86,48 @@ public class MascotGenerationPersistService {
         MascotGeneration gen = generationRepository.findById(generationId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MASCOT_GENERATION_NOT_FOUND));
         gen.failRigging(reason);
+        return gen;
+    }
+
+    /** retarget task 1개 생성 후 PROCESSING 전환. */
+    @Transactional
+    public MascotGeneration applyRetargetStarted(Long generationId, String retargetTaskId) {
+        MascotGeneration gen = generationRepository.findById(generationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MASCOT_GENERATION_NOT_FOUND));
+        gen.startRetarget(retargetTaskId);
+        return gen;
+    }
+
+    /**
+     * retarget GLB 다운로드 완료: generation.animModelUrl 저장 + tb_mascot.animModelUrl/animClips 반영.
+     *
+     * @param animClips MascotMotion.clipMap() — 상태→클립명 (Unity용)
+     */
+    @Transactional
+    public MascotGeneration applyRetargetComplete(Long siteId, Long generationId,
+                                                   String animModelUrl, Map<String, String> animClips) {
+        MascotGeneration gen = generationRepository.findById(generationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MASCOT_GENERATION_NOT_FOUND));
+        gen.completeRetarget(animModelUrl);
+
+        mascotRepository.findBySite_SiteId(siteId).ifPresentOrElse(
+                mascot -> {
+                    mascot.updateAnimation(animModelUrl, animClips);
+                    log.info("tb_mascot animModelUrl 업데이트: siteId={}, animClips={}", siteId, animClips.keySet());
+                },
+                () -> log.warn("tb_mascot 미존재 — animModelUrl 업데이트 생략: siteId={}, generationId={}",
+                        siteId, generationId)
+        );
+        return gen;
+    }
+
+    /** retarget 실패 — generation을 FAILED로 마킹하지 않음(base GLB는 확보됨). */
+    @Transactional
+    public MascotGeneration applyRetargetFailed(Long generationId, String reason) {
+        MascotGeneration gen = generationRepository.findById(generationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MASCOT_GENERATION_NOT_FOUND));
+        gen.failRetarget(reason);
+        log.warn("retarget 실패(base GLB 유지): generationId={}, reason={}", generationId, reason);
         return gen;
     }
 }

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationPersistService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationPersistService.java
@@ -69,9 +69,10 @@ public class MascotGenerationPersistService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MASCOT_GENERATION_NOT_FOUND));
         gen.completeRigging(modelUrl);
 
-        // tb_mascot에 base model_url 자동 업데이트
+        // tb_mascot에 base model_url 업데이트 (재생성 시 옛 anim 메타데이터 먼저 초기화)
         mascotRepository.findBySite_SiteId(siteId).ifPresentOrElse(
                 mascot -> {
+                    mascot.clearAnimation();
                     mascot.updateModelUrl(modelUrl, "glb", gen);
                     log.info("tb_mascot model_url 업데이트: siteId={}", siteId);
                 },

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationService.java
@@ -136,6 +136,17 @@ public class MascotGenerationService {
             return GenerationStatusResponse.from(gen);
         }
 
+        // 복구 분기: rig=SUCCESS & retarget=PENDING → retarget task 생성 중 예외로 정체된 케이스
+        // 다음 폴링 시 retarget task를 재생성해 파이프라인을 재개한다. base GLB 재다운로드 없음.
+        if (gen.getRigStatus() == GenerationStatus.SUCCESS
+                && gen.getRetargetStatus() == GenerationStatus.PENDING) {
+            log.warn("retarget 정체 감지, retarget task 재시도: generationId={}", generationId);
+            String retargetTaskId = tripoApiService.createAnimateRetargetTask(
+                    gen.getRigTaskId(), MascotMotion.presetList());
+            gen = persistService.applyRetargetStarted(generationId, retargetTaskId);
+            return GenerationStatusResponse.from(gen);
+        }
+
         // Phase 3: retarget 중 (단일 task 폴링)
         if (gen.getRetargetStatus() == GenerationStatus.PROCESSING) {
             TripoApiService.TripoTaskStatus status = tripoApiService.getTaskStatus(gen.getRetargetTaskId());

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationService.java
@@ -21,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * 마스코트 3D 모델 생성 파이프라인 오케스트레이션.
  *
+ * 파이프라인: image_to_model → animate_rig → animate_retarget(5클립 배열) → GLB 저장
+ *
  * 외부 API 호출은 트랜잭션 밖에서 수행하고,
  * DB 저장/업데이트는 MascotGenerationPersistService를 통해 별도 트랜잭션으로 처리.
  */
@@ -37,7 +39,6 @@ public class MascotGenerationService {
 
     /**
      * Step 1: 선업로드된 이미지 URL을 받아 Tripo 3D 생성 task 시작
-     * 외부 API 호출 후 DB 저장 (트랜잭션 분리)
      */
     public StartGenerationResponse startGeneration(Long siteId, String imageUrl,
                                                     CustomAdminDetails adminDetails) {
@@ -54,14 +55,12 @@ public class MascotGenerationService {
                             "이미 진행 중인 3D 생성 작업이 있습니다: " + gen.getGenerationId());
                 });
 
-        // 선업로드된 이미지를 로컬에서 읽어 Tripo로 재전송
         byte[] imageBytes = fileStorageService.loadBytes(siteId, imageUrl);
         String filename = imageUrl.substring(imageUrl.lastIndexOf('/') + 1);
 
         String imageToken = tripoApiService.uploadImage(imageBytes, filename);
         String modelTaskId = tripoApiService.createImageToModelTask(imageToken);
 
-        // DB 저장 (별도 트랜잭션)
         MascotGeneration generation = persistService.saveNewGeneration(site, imageUrl, modelTaskId);
 
         log.info("마스코트 3D 생성 시작: generationId={}, siteId={}, modelTaskId={}",
@@ -75,24 +74,24 @@ public class MascotGenerationService {
     }
 
     /**
-     * Step 2: 생성 상태 폴링 — model task → rig task → GLB 다운로드 자동 진행
-     * 외부 API 호출은 트랜잭션 밖, 상태 변경은 별도 트랜잭션
+     * Step 2: 생성 상태 폴링
+     *
+     * Phase 1 (model)  → success: animate_rig 시작
+     * Phase 2 (rig)    → success: base GLB 저장 + animate_retarget(5클립 배열) 시작
+     * Phase 3 (retarget) → success: anim GLB 저장 (5클립 내장)
      */
     public GenerationStatusResponse pollStatus(Long siteId, Long generationId,
                                                 CustomAdminDetails adminDetails) {
         validatePlatformAdmin(adminDetails);
 
-        // 1. 읽기 전용 트랜잭션: 로드 + IDOR 검증
         MascotGeneration gen = persistService.loadAndValidate(siteId, generationId);
 
-        // 이미 완료 or 실패면 바로 반환
         if (gen.isFullyCompleted() || gen.isFailed()) {
             return GenerationStatusResponse.from(gen);
         }
 
         // Phase 1: model 생성 중
         if (gen.getModelStatus() == GenerationStatus.PROCESSING) {
-            // 외부 API 호출 (트랜잭션 밖)
             TripoApiService.TripoTaskStatus status = tripoApiService.getTaskStatus(gen.getModelTaskId());
 
             if (status.isFailed()) {
@@ -102,10 +101,8 @@ public class MascotGenerationService {
             }
 
             if (status.isSuccess()) {
-                log.info("마스코트 model 생성 완료, rigging 시작: generationId={}", generationId);
-                // 외부 API 호출 (트랜잭션 밖)
+                log.info("마스코트 model 완료, rigging 시작: generationId={}", generationId);
                 String rigTaskId = tripoApiService.createAnimateRigTask(gen.getModelTaskId());
-                // DB 업데이트 (별도 트랜잭션)
                 gen = persistService.applyModelComplete(generationId, rigTaskId);
             }
 
@@ -114,7 +111,6 @@ public class MascotGenerationService {
 
         // Phase 2: rigging 중
         if (gen.getRigStatus() == GenerationStatus.PROCESSING) {
-            // 외부 API 호출 (트랜잭션 밖)
             TripoApiService.TripoTaskStatus status = tripoApiService.getTaskStatus(gen.getRigTaskId());
 
             if (status.isFailed()) {
@@ -124,13 +120,39 @@ public class MascotGenerationService {
             }
 
             if (status.isSuccess() && status.modelUrl() != null) {
-                // 외부 IO (트랜잭션 밖): GLB 다운로드 → 로컬 저장
+                // base GLB 다운로드 → 저장
                 byte[] glbBytes = tripoApiService.downloadModel(status.modelUrl());
                 String glbHash = FileValidator.computeFileHash(glbBytes);
                 String modelUrl = fileStorageService.store(siteId, glbHash, glbBytes, "mascot.glb");
-                // DB 업데이트 (별도 트랜잭션)
                 gen = persistService.applyRigComplete(siteId, generationId, modelUrl);
-                log.info("마스코트 3D 생성 완전 완료: generationId={}, modelUrl={}", generationId, modelUrl);
+                log.info("base GLB 저장 완료, retarget 시작: generationId={}", generationId);
+
+                // animate_retarget: 5클립 배열 1개 task
+                String retargetTaskId = tripoApiService.createAnimateRetargetTask(
+                        gen.getRigTaskId(), MascotMotion.presetList());
+                gen = persistService.applyRetargetStarted(generationId, retargetTaskId);
+            }
+
+            return GenerationStatusResponse.from(gen);
+        }
+
+        // Phase 3: retarget 중 (단일 task 폴링)
+        if (gen.getRetargetStatus() == GenerationStatus.PROCESSING) {
+            TripoApiService.TripoTaskStatus status = tripoApiService.getTaskStatus(gen.getRetargetTaskId());
+
+            if (status.isFailed()) {
+                gen = persistService.applyRetargetFailed(generationId, "Tripo retarget 실패");
+                return GenerationStatusResponse.from(gen);
+            }
+
+            if (status.isSuccess() && status.modelUrl() != null) {
+                // anim GLB(5클립 내장) 다운로드 → 저장
+                byte[] animBytes = tripoApiService.downloadModel(status.modelUrl());
+                String animHash = FileValidator.computeFileHash(animBytes);
+                String animModelUrl = fileStorageService.store(siteId, animHash, animBytes, "mascot_anim.glb");
+                gen = persistService.applyRetargetComplete(
+                        siteId, generationId, animModelUrl, MascotMotion.clipMap());
+                log.info("마스코트 생성 완전 완료: generationId={}, animModelUrl={}", generationId, animModelUrl);
             }
 
             return GenerationStatusResponse.from(gen);

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotMotion.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotMotion.java
@@ -1,0 +1,46 @@
+package com.guideon.guideonbackend.domain.mascot.service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 키오스크 상태 ↔ Tripo animate_retarget 프리셋 모션 매핑.
+ *
+ * Tripo rig 기본 버전: v1.0-20240301 (biped) → 프리셋 형식: preset:biped:*
+ *
+ * Unity는 animClips 맵의 key(state)로 상태를 식별하고, value(preset)로 클립 이름을 찾아 재생.
+ */
+public enum MascotMotion {
+
+    IDLE      ("idle",      "preset:biped:idle"),
+    SPEAKING  ("speaking",  "preset:biped:sing_01"),   // 입·상체 제스처 (실제 TTS 립싱크는 jaw bone)
+    LISTENING ("listening", "preset:biped:wait"),
+    THINKING  ("thinking",  "preset:biped:scratch"),   // 머리 긁적이는 고민 포즈
+    GREETING  ("greeting",  "preset:biped:greet_01");
+
+    private final String state;        // animClips 맵 key / Unity 상태 식별자
+    private final String tripoPreset;  // Tripo animations 배열에 넘기는 값 / GLB 내부 클립명
+
+    MascotMotion(String state, String tripoPreset) {
+        this.state = state;
+        this.tripoPreset = tripoPreset;
+    }
+
+    public String getState()       { return state; }
+    public String getTripoPreset() { return tripoPreset; }
+
+    /** Tripo animations 배열용 preset 리스트 (순서 유지). */
+    public static List<String> presetList() {
+        return Arrays.stream(values())
+                .map(MascotMotion::getTripoPreset)
+                .collect(Collectors.toList());
+    }
+
+    /** Unity에 내려줄 animClips 맵 (state → tripoPreset = GLB 내부 클립명). */
+    public static Map<String, String> clipMap() {
+        return Arrays.stream(values())
+                .collect(Collectors.toMap(MascotMotion::getState, MascotMotion::getTripoPreset));
+    }
+}

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/TripoApiService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/TripoApiService.java
@@ -12,6 +12,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -116,6 +117,30 @@ public class TripoApiService {
         String taskId = (String) data.get("task_id");
 
         log.info("Tripo animate_rig task 생성: taskId={}", taskId);
+        return taskId;
+    }
+
+    /**
+     * Step 4: animate_retarget task 생성 (리깅된 모델 + 5클립 배열 → GLB 1개) → task_id 반환
+     *
+     * @param rigTaskId animate_rig 완료된 task_id
+     * @param presets   Tripo preset 식별자 목록 ({@link MascotMotion#presetList()}, 최대 5개)
+     */
+    public String createAnimateRetargetTask(String rigTaskId, List<String> presets) {
+        String url = baseUrl + "/task";
+
+        Map<String, Object> requestBody = Map.of(
+                "type", "animate_retarget",
+                "original_model_task_id", rigTaskId,
+                "out_format", "glb",
+                "animations", presets
+        );
+
+        Map<String, Object> response = postJson(url, requestBody);
+        Map<String, Object> data = extractData(response);
+        String taskId = (String) data.get("task_id");
+
+        log.info("Tripo animate_retarget task 생성: presets={}, taskId={}", presets, taskId);
         return taskId;
     }
 

--- a/guideon-core/src/main/java/com/guideon/core/domain/mascot/entity/Mascot.java
+++ b/guideon-core/src/main/java/com/guideon/core/domain/mascot/entity/Mascot.java
@@ -124,4 +124,13 @@ public class Mascot extends BaseEntity {
         this.animModelUrl = animModelUrl;
         this.animClips = animClips != null ? animClips : new HashMap<>();
     }
+
+    /**
+     * rig 재생성 시작 시 이전 애니메이션 메타데이터 초기화.
+     * 새 base GLB와 옛 animModelUrl이 함께 서빙되는 스켈레톤 불일치를 방지.
+     */
+    public void clearAnimation() {
+        this.animModelUrl = null;
+        this.animClips = new HashMap<>();
+    }
 }

--- a/guideon-core/src/main/java/com/guideon/core/domain/mascot/entity/Mascot.java
+++ b/guideon-core/src/main/java/com/guideon/core/domain/mascot/entity/Mascot.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Entity
@@ -62,6 +63,15 @@ public class Mascot extends BaseEntity {
     @Column(name = "model_format", length = 10)
     private String modelFormat;
 
+    /** retarget 완료 GLB (5클립 내장). Unity 노출 소스. */
+    @Column(name = "anim_model_url", length = 500)
+    private String animModelUrl;
+
+    /** 상태→클립명 매핑 (예: {idle:"preset:biped:idle", ...}). Unity가 상태별 Animation.Play() 호출에 사용. */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "anim_clips", nullable = false, columnDefinition = "jsonb")
+    private Map<String, String> animClips;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "generation_id", unique = true)
     private MascotGeneration generation;
@@ -83,6 +93,7 @@ public class Mascot extends BaseEntity {
         this.ttsVoiceId = ttsVoiceId;
         this.ttsVoiceJson = ttsVoiceJson;
         this.imageUrl = imageUrl;
+        this.animClips = new HashMap<>();
         this.isActive = true;
     }
 
@@ -106,5 +117,11 @@ public class Mascot extends BaseEntity {
         this.modelUrl = modelUrl;
         this.modelFormat = (modelFormat != null && !modelFormat.isBlank()) ? modelFormat : "glb";
         this.generation = generation;
+    }
+
+    /** retarget 완료 시 animModelUrl(5클립 GLB) + animClips(상태→클립명 맵) 반영. */
+    public void updateAnimation(String animModelUrl, Map<String, String> animClips) {
+        this.animModelUrl = animModelUrl;
+        this.animClips = animClips != null ? animClips : new HashMap<>();
     }
 }

--- a/guideon-core/src/main/java/com/guideon/core/domain/mascot/entity/MascotGeneration.java
+++ b/guideon-core/src/main/java/com/guideon/core/domain/mascot/entity/MascotGeneration.java
@@ -40,6 +40,17 @@ public class MascotGeneration extends BaseEntity {
     @Column(name = "rig_status", nullable = false, length = 20)
     private GenerationStatus rigStatus;
 
+    // animate_retarget: animations 배열 1개 task → GLB 1개에 5클립
+    @Enumerated(EnumType.STRING)
+    @Column(name = "retarget_status", nullable = false, length = 20)
+    private GenerationStatus retargetStatus;
+
+    @Column(name = "retarget_task_id", length = 100)
+    private String retargetTaskId;
+
+    @Column(name = "anim_model_url", length = 500)
+    private String animModelUrl;  // retarget 완료 GLB URL
+
     @Column(name = "result_model_url", length = 500)
     private String resultModelUrl;
 
@@ -52,7 +63,10 @@ public class MascotGeneration extends BaseEntity {
         this.sourceImageUrl = sourceImageUrl;
         this.modelStatus = GenerationStatus.PENDING;
         this.rigStatus = GenerationStatus.PENDING;
+        this.retargetStatus = GenerationStatus.PENDING;
     }
+
+    // ── model 단계 ──
 
     public void startModelGeneration(String modelTaskId) {
         this.modelTaskId = modelTaskId;
@@ -67,6 +81,8 @@ public class MascotGeneration extends BaseEntity {
         this.modelStatus = GenerationStatus.FAILED;
         this.failedReason = appendReason(this.failedReason, reason);
     }
+
+    // ── rig 단계 ──
 
     public void startRigging(String rigTaskId) {
         this.rigTaskId = rigTaskId;
@@ -83,27 +99,50 @@ public class MascotGeneration extends BaseEntity {
         this.failedReason = appendReason(this.failedReason, reason);
     }
 
-    public boolean isFullyCompleted() {
-        return modelStatus == GenerationStatus.SUCCESS && rigStatus == GenerationStatus.SUCCESS;
+    // ── retarget 단계 (animations 배열 1개 task) ──
+
+    public void startRetarget(String retargetTaskId) {
+        this.retargetTaskId = retargetTaskId;
+        this.retargetStatus = GenerationStatus.PROCESSING;
     }
 
+    public void completeRetarget(String animModelUrl) {
+        this.retargetStatus = GenerationStatus.SUCCESS;
+        this.animModelUrl = animModelUrl;
+    }
+
+    /** retarget 실패는 치명적이지 않음 — base GLB는 이미 확보됨. */
+    public void failRetarget(String reason) {
+        this.retargetStatus = GenerationStatus.FAILED;
+        this.failedReason = appendReason(this.failedReason, "retarget: " + reason);
+    }
+
+    // ── 완료/실패 판단 ──
+
+    /**
+     * retarget은 SUCCESS/FAILED 어느 쪽이든 종료되면 완료로 간주.
+     * (base GLB는 rig 완료 시점에 이미 확보됨)
+     */
+    public boolean isFullyCompleted() {
+        return modelStatus == GenerationStatus.SUCCESS
+                && rigStatus == GenerationStatus.SUCCESS
+                && (retargetStatus == GenerationStatus.SUCCESS
+                        || retargetStatus == GenerationStatus.FAILED);
+    }
+
+    /** model/rig 실패만 전체 실패 — retarget 실패는 폴백 허용. */
     public boolean isFailed() {
         return modelStatus == GenerationStatus.FAILED || rigStatus == GenerationStatus.FAILED;
     }
 
-    // status를 String으로 반환 (하위 호환)
-    public String getModelStatusValue() {
-        return modelStatus.name();
-    }
+    // ── 상태값 문자열 반환 (하위 호환) ──
 
-    public String getRigStatusValue() {
-        return rigStatus.name();
-    }
+    public String getModelStatusValue() { return modelStatus.name(); }
+    public String getRigStatusValue()   { return rigStatus.name(); }
+    public String getRetargetStatusValue() { return retargetStatus.name(); }
 
     private String appendReason(String existing, String newReason) {
-        if (existing == null || existing.isBlank()) {
-            return newReason;
-        }
+        if (existing == null || existing.isBlank()) return newReason;
         return existing + " | " + newReason;
     }
 }

--- a/guideon-core/src/main/java/com/guideon/core/dto/kiosk/KioskBootstrapDto.java
+++ b/guideon-core/src/main/java/com/guideon/core/dto/kiosk/KioskBootstrapDto.java
@@ -39,5 +39,7 @@ public class KioskBootstrapDto {
         private String greetingMsg;
         private String ttsVoiceId;
         private Map<String, Object> ttsVoiceJson;
+        private String animModelUrl;           // 5클립 내장 GLB URL (없으면 프로시저럴 폴백)
+        private Map<String, String> animClips; // 상태→클립명 (Unity Animation.Play 키)
     }
 }

--- a/guideon-core/src/main/java/com/guideon/core/dto/kiosk/KioskMascotDto.java
+++ b/guideon-core/src/main/java/com/guideon/core/dto/kiosk/KioskMascotDto.java
@@ -25,6 +25,8 @@ public class KioskMascotDto {
     private Map<String, Object> promptConfig;
     private String ttsVoiceId;
     private Map<String, Object> ttsVoiceJson;
+    private String animModelUrl;           // 5클립 내장 GLB URL (없으면 프로시저럴 폴백)
+    private Map<String, String> animClips; // 상태→클립명 (Unity Animation.Play 키)
 
     public static KioskMascotDto from(Mascot mascot) {
         return KioskMascotDto.builder()
@@ -39,6 +41,8 @@ public class KioskMascotDto {
                 .promptConfig(mascot.getPromptConfig())
                 .ttsVoiceId(mascot.getTtsVoiceId())
                 .ttsVoiceJson(mascot.getTtsVoiceJson())
+                .animModelUrl(mascot.getAnimModelUrl())
+                .animClips(mascot.getAnimClips())
                 .build();
     }
 }

--- a/guideon-core/src/main/java/com/guideon/core/service/KioskService.java
+++ b/guideon-core/src/main/java/com/guideon/core/service/KioskService.java
@@ -54,6 +54,8 @@ public class KioskService {
                         .greetingMsg(m.getGreetingMsg())
                         .ttsVoiceId(m.getTtsVoiceId())
                         .ttsVoiceJson(m.getTtsVoiceJson())
+                        .animModelUrl(m.getAnimModelUrl())
+                        .animClips(m.getAnimClips())
                         .build())
                 .orElse(null);
 

--- a/infra/init.sql
+++ b/infra/init.sql
@@ -220,6 +220,11 @@ CREATE TABLE IF NOT EXISTS tb_mascot_generation (
   rig_task_id        VARCHAR(100) NULL,
   rig_status         VARCHAR(20) NOT NULL DEFAULT 'PENDING',
 
+  -- animate_retarget task 추적 (animations 배열 1개 task → GLB 1개에 5클립)
+  retarget_status    VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+  retarget_task_id   VARCHAR(100) NULL,            -- retarget 단일 task_id
+  anim_model_url     VARCHAR(500) NULL,            -- retarget 완료 GLB URL
+
   -- 결과
   result_model_url   VARCHAR(500) NULL,
   failed_reason      TEXT NULL,
@@ -228,7 +233,8 @@ CREATE TABLE IF NOT EXISTS tb_mascot_generation (
   updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
   CONSTRAINT ck_model_status CHECK (model_status IN ('PENDING','PROCESSING','SUCCESS','FAILED')),
-  CONSTRAINT ck_rig_status CHECK (rig_status IN ('PENDING','PROCESSING','SUCCESS','FAILED'))
+  CONSTRAINT ck_rig_status CHECK (rig_status IN ('PENDING','PROCESSING','SUCCESS','FAILED')),
+  CONSTRAINT ck_retarget_status CHECK (retarget_status IN ('PENDING','PROCESSING','SUCCESS','FAILED'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_mascot_gen_site ON tb_mascot_generation (site_id, model_status);
@@ -242,6 +248,20 @@ FOR EACH ROW EXECUTE FUNCTION guideon_set_updated_at();
 ALTER TABLE tb_mascot ADD COLUMN IF NOT EXISTS model_url VARCHAR(500) NULL;
 ALTER TABLE tb_mascot ADD COLUMN IF NOT EXISTS model_format VARCHAR(10) NULL DEFAULT 'glb';
 ALTER TABLE tb_mascot ADD COLUMN IF NOT EXISTS generation_id BIGINT NULL UNIQUE REFERENCES tb_mascot_generation(generation_id) ON DELETE SET NULL;
+
+-- 상태별 애니메이션 (5클립 GLB 단일 URL + 상태→클립명 매핑). Unity 노출 소스
+ALTER TABLE tb_mascot ADD COLUMN IF NOT EXISTS anim_model_url VARCHAR(500) NULL;
+ALTER TABLE tb_mascot ADD COLUMN IF NOT EXISTS anim_clips JSONB NOT NULL DEFAULT '{}';
+
+-- 기존 운영 DB용 멱등 컬럼 추가 (tb_mascot_generation retarget 추적)
+ALTER TABLE tb_mascot_generation ADD COLUMN IF NOT EXISTS retarget_status VARCHAR(20) NOT NULL DEFAULT 'PENDING';
+ALTER TABLE tb_mascot_generation ADD COLUMN IF NOT EXISTS retarget_task_id VARCHAR(100) NULL;
+ALTER TABLE tb_mascot_generation ADD COLUMN IF NOT EXISTS anim_model_url VARCHAR(500) NULL;
+
+DO $$ BEGIN
+  ALTER TABLE tb_mascot_generation ADD CONSTRAINT ck_retarget_status
+    CHECK (retarget_status IN ('PENDING','PROCESSING','SUCCESS','FAILED'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 -- tb_document
 CREATE TABLE IF NOT EXISTS tb_document (


### PR DESCRIPTION
## Summary
- #182 
- Tripo AI `animate_retarget` API를 활용해 마스코트 상태별 애니메이션(idle/speaking/listening/thinking/greeting) GLB를 자동 생성하는 파이프라인 추가

## Tasks
 - [x] DB 스키마 추가 — `tb_mascot_generation.retarget_task_id/anim_model_url`, `tb_mascot.anim_model_url/anim_clips`
- [x] `MascotGeneration` / `Mascot` 엔티티 필드 및 상태전이 메서드 추가
- [x] `MascotMotion` enum — 키오스크 상태 → Tripo `preset:biped:*` 매핑
- [x] `TripoApiService.createAnimateRetargetTask()` — `animations` 배열 1개 task (5클립 GLB 단일 생성)
- [x] `MascotGenerationService` Phase 3(retarget) 폴링 단계 추가
- [x] Bootstrap / Mascot 응답에 `animModelUrl`, `animClips` 노출

## To Reviewer
- retarget은 `animations` 배열(최대 5개) 방식으로 **task 1개 → GLB 1개에 5클립 내장** 합니다.
- retarget 실패는 치명적이지 않음 — `isFailed()`에서 제외, base GLB(`modelUrl`) 유지 + Unity 프로시저럴 폴백을 수행합니다.
- `MascotMotion` enum의 Tripo preset 값(`preset:biped:idle` 등)은 v1.0-20240301(biped) 기준. Unity 연동 검증 시 GLB 내부 실제 클립명 확인 필요합니다.
- 운영 DB 배포 전 `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` 수동 실행 필요합니다.

## Screenshot
<img src="" width="50%" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 마스코트 생성 파이프라인에 애니메이션 리타겟팅 단계가 추가되었습니다.
  * 생성된 마스코트가 유휴, 대화, 청취, 사고, 인사 등 다양한 애니메이션 모션을 지원합니다.
  * 애니메이션 모델 데이터가 키오스크 부트스트랩 응답에 포함되어 동적 애니메이션 재생이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->