### PR TITLE
 feat: 마스코트 애니메이션 자동화 파이프라인 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,6 +147,22 @@ services:
       - guideon-net
     restart: always
 
+  # 6. mesh-processor (gltf-transform 기반 GLB 병합)
+  mesh-processor:
+    build:
+      context: ./mesh-processor
+      dockerfile: Dockerfile
+    container_name: guideon-mesh-processor
+    volumes:
+      - ./uploads:/app/uploads   # admin-bff와 동일 볼륨 공유 (파일 경로 직접 접근)
+    environment:
+      - PORT=3001
+      - STORAGE_PATH=/app/uploads
+    networks:
+      - guideon-net
+    restart: unless-stopped
+    # 외부 포트 노출 없음 — admin-bff에서만 http://mesh-processor:3001 로 접근
+
 volumes:
   postgres_data:
 

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/controller/MascotController.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/controller/MascotController.java
@@ -5,6 +5,7 @@ import com.guideon.common.exception.ErrorCode;
 import com.guideon.common.response.ApiResponse;
 import com.guideon.guideonbackend.domain.mascot.dto.*;
 import org.springframework.lang.Nullable;
+import com.guideon.guideonbackend.domain.mascot.service.MascotAnimConfigService;
 import com.guideon.guideonbackend.domain.mascot.service.MascotGenerationService;
 import com.guideon.guideonbackend.domain.mascot.service.MascotService;
 import com.guideon.guideonbackend.global.security.CustomAdminDetails;
@@ -28,6 +29,7 @@ public class MascotController {
 
     private final MascotService mascotService;
     private final MascotGenerationService generationService;
+    private final MascotAnimConfigService animConfigService;
 
     @Operation(summary = "마스코트 이미지 업로드", description = "마스코트 이미지를 업로드하고 URL을 반환합니다. PLATFORM_ADMIN 권한 필요")
     @PostMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -122,6 +124,63 @@ public class MascotController {
             throw new CustomException(ErrorCode.VALIDATION_ERROR, "언어 코드는 필수입니다.");
         }
         VoiceCloneResponse response = mascotService.cloneVoice(siteId, audioFile, name, language, adminDetails);
+        String traceId = (String) httpRequest.getAttribute(TraceIdUtil.TRACE_ID_ATTR);
+        return ResponseEntity.ok(ApiResponse.success(response, traceId));
+    }
+
+    // ── 애니메이션 설정 (Mixamo GLB 업로드 / 매핑 관리) ──
+
+    @Operation(
+            summary = "상태별 애니메이션 GLB 업로드",
+            description = "Mixamo에서 준비한 state별 GLB 파일을 업로드합니다. " +
+                    "업로드 후 마스코트 생성(rig 완료) 시 자동으로 anim GLB가 병합됩니다. " +
+                    "각 state 파트명: idle / speaking / listening / thinking / greeting. " +
+                    "PLATFORM_ADMIN 권한 필요")
+    @PostMapping(value = "/animations", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<AnimationGlbsUploadResponse>> uploadAnimationGlbs(
+            @PathVariable Long siteId,
+            @RequestPart(value = "idle",      required = false) MultipartFile idle,
+            @RequestPart(value = "speaking",  required = false) MultipartFile speaking,
+            @RequestPart(value = "listening", required = false) MultipartFile listening,
+            @RequestPart(value = "thinking",  required = false) MultipartFile thinking,
+            @RequestPart(value = "greeting",  required = false) MultipartFile greeting,
+            @AuthenticationPrincipal CustomAdminDetails adminDetails,
+            HttpServletRequest httpRequest
+    ) {
+        java.util.Map<String, MultipartFile> files = new java.util.LinkedHashMap<>();
+        if (idle      != null) files.put("idle",      idle);
+        if (speaking  != null) files.put("speaking",  speaking);
+        if (listening != null) files.put("listening", listening);
+        if (thinking  != null) files.put("thinking",  thinking);
+        if (greeting  != null) files.put("greeting",  greeting);
+
+        AnimationGlbsUploadResponse response = animConfigService.uploadAnimationGlbs(siteId, files, adminDetails);
+        String traceId = (String) httpRequest.getAttribute(TraceIdUtil.TRACE_ID_ATTR);
+        return ResponseEntity.ok(ApiResponse.success(response, traceId));
+    }
+
+    @Operation(summary = "애니메이션 설정 조회", description = "현재 상태→클립명 매핑과 GLB URL을 조회합니다.")
+    @GetMapping("/anim-config")
+    public ResponseEntity<ApiResponse<AnimConfigResponse>> getAnimConfig(
+            @PathVariable Long siteId,
+            @AuthenticationPrincipal CustomAdminDetails adminDetails,
+            HttpServletRequest httpRequest
+    ) {
+        AnimConfigResponse response = animConfigService.getAnimConfig(siteId, adminDetails);
+        String traceId = (String) httpRequest.getAttribute(TraceIdUtil.TRACE_ID_ATTR);
+        return ResponseEntity.ok(ApiResponse.success(response, traceId));
+    }
+
+    @Operation(summary = "애니메이션 클립명 수정",
+            description = "GLB 파일 변경 없이 상태→클립명 매핑만 수정합니다.")
+    @PutMapping("/anim-config")
+    public ResponseEntity<ApiResponse<AnimConfigResponse>> updateAnimConfig(
+            @PathVariable Long siteId,
+            @RequestBody AnimConfigRequest request,
+            @AuthenticationPrincipal CustomAdminDetails adminDetails,
+            HttpServletRequest httpRequest
+    ) {
+        AnimConfigResponse response = animConfigService.updateAnimConfig(siteId, request, adminDetails);
         String traceId = (String) httpRequest.getAttribute(TraceIdUtil.TRACE_ID_ATTR);
         return ResponseEntity.ok(ApiResponse.success(response, traceId));
     }

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/dto/AnimConfigRequest.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/dto/AnimConfigRequest.java
@@ -1,0 +1,15 @@
+package com.guideon.guideonbackend.domain.mascot.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/** PUT /mascot/anim-config 요청 — 클립명 매핑만 수정 (GLB 파일 변경 없음) */
+@Getter
+@NoArgsConstructor
+public class AnimConfigRequest {
+
+    /** 수정할 상태→클립명 맵. 전달된 state_key만 업데이트됨. */
+    private Map<String, String> animClips;
+}

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/dto/AnimConfigResponse.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/dto/AnimConfigResponse.java
@@ -1,0 +1,18 @@
+package com.guideon.guideonbackend.domain.mascot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+/** GET /mascot/anim-config 응답 — 현재 상태→클립명 매핑 */
+@Getter
+@Builder
+public class AnimConfigResponse {
+
+    /** 상태→클립명 (예: {idle:"Idle", speaking:"Talking", ...}) */
+    private Map<String, String> animClips;
+
+    /** 상태→GLB URL (업로드된 원본 GLB 경로) */
+    private Map<String, String> animGlbUrls;
+}

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/dto/AnimationGlbsUploadResponse.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/dto/AnimationGlbsUploadResponse.java
@@ -1,0 +1,22 @@
+package com.guideon.guideonbackend.domain.mascot.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/** POST /mascot/animations 응답 */
+@Getter
+@Builder
+public class AnimationGlbsUploadResponse {
+
+    private List<UploadedClip> uploaded;
+
+    @Getter
+    @Builder
+    public static class UploadedClip {
+        private String stateKey;  // idle | speaking | listening | thinking | greeting
+        private String clipName;  // Idle | Talking | Listening | Thinking | Waving
+        private String glbUrl;    // 저장된 GLB URL
+    }
+}

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotAnimConfigService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotAnimConfigService.java
@@ -1,0 +1,166 @@
+package com.guideon.guideonbackend.domain.mascot.service;
+
+import com.guideon.common.exception.CustomException;
+import com.guideon.common.exception.ErrorCode;
+import com.guideon.core.domain.admin.entity.AdminRole;
+import com.guideon.core.domain.mascot.entity.MascotAnimConfig;
+import com.guideon.core.domain.mascot.repository.MascotAnimConfigRepository;
+import com.guideon.guideonbackend.domain.mascot.dto.AnimConfigRequest;
+import com.guideon.guideonbackend.domain.mascot.dto.AnimConfigResponse;
+import com.guideon.guideonbackend.domain.mascot.dto.AnimationGlbsUploadResponse;
+import com.guideon.guideonbackend.global.security.CustomAdminDetails;
+import com.guideon.guideonbackend.global.storage.FileStorageService;
+import com.guideon.guideonbackend.global.storage.FileValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 마스코트 애니메이션 설정(tb_mascot_anim_config) 관리.
+ * 사이트별 state→clip GLB를 1회 설정하면, 이후 마스코트 생성 시 자동으로 anim GLB가 병합된다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MascotAnimConfigService {
+
+    /** state_key → 기본 clip_name 매핑 (담당자가 설정하지 않은 경우 사용) */
+    private static final Map<String, String> DEFAULT_CLIP_NAMES = Map.of(
+            "idle",      "Idle",
+            "speaking",  "Talking",
+            "listening", "Listening",
+            "thinking",  "Thinking",
+            "greeting",  "Waving"
+    );
+
+    private final MascotAnimConfigRepository animConfigRepository;
+    private final FileStorageService fileStorageService;
+
+    /**
+     * state별 GLB 파일 업로드.
+     * 각 state에 대해 기존 레코드가 있으면 업데이트, 없으면 신규 생성(upsert).
+     *
+     * @param files state_key → MultipartFile 맵 (전달된 state만 처리)
+     */
+    @Transactional
+    public AnimationGlbsUploadResponse uploadAnimationGlbs(
+            Long siteId,
+            Map<String, MultipartFile> files,
+            CustomAdminDetails adminDetails) {
+
+        validatePlatformAdmin(adminDetails);
+
+        if (files == null || files.isEmpty()) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "업로드할 GLB 파일이 없습니다.");
+        }
+
+        List<AnimationGlbsUploadResponse.UploadedClip> uploaded = new ArrayList<>();
+
+        for (Map.Entry<String, MultipartFile> entry : files.entrySet()) {
+            String stateKey = entry.getKey();
+            MultipartFile file = entry.getValue();
+
+            if (file == null || file.isEmpty()) continue;
+
+            if (!DEFAULT_CLIP_NAMES.containsKey(stateKey)) {
+                throw new CustomException(ErrorCode.VALIDATION_ERROR,
+                        "유효하지 않은 state_key: " + stateKey
+                        + ". 허용값: " + DEFAULT_CLIP_NAMES.keySet());
+            }
+
+            FileValidator.validateGlb(file);
+            String fileHash = FileValidator.computeFileHash(file);
+            String glbUrl   = fileStorageService.store(siteId, fileHash, file);
+
+            // 기존 레코드 upsert
+            MascotAnimConfig config = animConfigRepository
+                    .findBySiteIdAndStateKey(siteId, stateKey)
+                    .orElse(null);
+
+            String clipName = DEFAULT_CLIP_NAMES.get(stateKey);
+
+            if (config == null) {
+                config = MascotAnimConfig.builder()
+                        .siteId(siteId)
+                        .stateKey(stateKey)
+                        .clipName(clipName)
+                        .glbUrl(glbUrl)
+                        .build();
+                animConfigRepository.save(config);
+            } else {
+                config.update(config.getClipName(), glbUrl); // 클립명은 유지, GLB만 교체
+            }
+
+            log.info("anim GLB 업로드: siteId={}, state={}, url={}", siteId, stateKey, glbUrl);
+            uploaded.add(AnimationGlbsUploadResponse.UploadedClip.builder()
+                    .stateKey(stateKey)
+                    .clipName(config.getClipName())
+                    .glbUrl(glbUrl)
+                    .build());
+        }
+
+        return AnimationGlbsUploadResponse.builder().uploaded(uploaded).build();
+    }
+
+    /**
+     * 현재 anim config 조회.
+     */
+    @Transactional(readOnly = true)
+    public AnimConfigResponse getAnimConfig(Long siteId, CustomAdminDetails adminDetails) {
+        validatePlatformAdmin(adminDetails);
+
+        List<MascotAnimConfig> configs = animConfigRepository.findBySiteId(siteId);
+
+        Map<String, String> animClips = configs.stream()
+                .collect(Collectors.toMap(MascotAnimConfig::getStateKey, MascotAnimConfig::getClipName));
+        Map<String, String> animGlbUrls = configs.stream()
+                .collect(Collectors.toMap(MascotAnimConfig::getStateKey, MascotAnimConfig::getGlbUrl));
+
+        return AnimConfigResponse.builder()
+                .animClips(animClips)
+                .animGlbUrls(animGlbUrls)
+                .build();
+    }
+
+    /**
+     * 클립명만 수정 (GLB 파일 변경 없음).
+     * 전달된 state_key만 업데이트.
+     */
+    @Transactional
+    public AnimConfigResponse updateAnimConfig(Long siteId, AnimConfigRequest request,
+                                               CustomAdminDetails adminDetails) {
+        validatePlatformAdmin(adminDetails);
+
+        if (request.getAnimClips() == null || request.getAnimClips().isEmpty()) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "animClips가 비어있습니다.");
+        }
+
+        for (Map.Entry<String, String> entry : request.getAnimClips().entrySet()) {
+            String stateKey  = entry.getKey();
+            String clipName  = entry.getValue();
+
+            MascotAnimConfig config = animConfigRepository
+                    .findBySiteIdAndStateKey(siteId, stateKey)
+                    .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND,
+                            "anim config 없음 — GLB를 먼저 업로드해주세요: state=" + stateKey));
+
+            config.updateClipName(clipName);
+            log.info("anim 클립명 수정: siteId={}, state={}, clipName={}", siteId, stateKey, clipName);
+        }
+
+        return getAnimConfig(siteId, adminDetails);
+    }
+
+    private void validatePlatformAdmin(CustomAdminDetails adminDetails) {
+        if (!AdminRole.PLATFORM_ADMIN.name().equals(adminDetails.getRole())) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+    }
+}

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationPersistService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationPersistService.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
+
 /**
  * MascotGeneration DB 저장/업데이트 전담.
  * 외부 API 호출 없이 트랜잭션 범위를 최소화.
@@ -86,6 +88,24 @@ public class MascotGenerationPersistService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MASCOT_GENERATION_NOT_FOUND));
         gen.failRigging(reason);
         return gen;
+    }
+
+    /**
+     * mesh-processor 병합 완료: tb_mascot.animModelUrl + animClips 반영.
+     * rig 완료 후 별도 트랜잭션으로 실행 (외부 호출 결과).
+     */
+    @Transactional
+    public void applyAnimationComplete(Long siteId, Long generationId,
+                                       String animModelUrl, Map<String, String> animClips) {
+        mascotRepository.findBySite_SiteId(siteId).ifPresentOrElse(
+                mascot -> {
+                    mascot.updateAnimation(animModelUrl, animClips);
+                    log.info("tb_mascot animModelUrl 자동 업데이트: siteId={}, clips={}",
+                            siteId, animClips.keySet());
+                },
+                () -> log.warn("tb_mascot 미존재 — animModelUrl 업데이트 생략: siteId={}, generationId={}",
+                        siteId, generationId)
+        );
     }
 
 }

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MascotGenerationService.java
@@ -4,7 +4,9 @@ import com.guideon.common.exception.CustomException;
 import com.guideon.common.exception.ErrorCode;
 import com.guideon.core.domain.admin.entity.AdminRole;
 import com.guideon.core.domain.mascot.entity.GenerationStatus;
+import com.guideon.core.domain.mascot.entity.MascotAnimConfig;
 import com.guideon.core.domain.mascot.entity.MascotGeneration;
+import com.guideon.core.domain.mascot.repository.MascotAnimConfigRepository;
 import com.guideon.core.domain.mascot.repository.MascotGenerationRepository;
 import com.guideon.core.domain.site.entity.Site;
 import com.guideon.core.domain.site.repository.SiteRepository;
@@ -18,11 +20,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 /**
  * 마스코트 3D 모델 생성 파이프라인 오케스트레이션.
  *
  * 파이프라인: image_to_model → animate_rig(spec:mixamo) → 리깅 GLB 저장
- * 애니메이션은 담당자가 Mixamo + Blender로 제작 후 POST /mascot/animation으로 별도 업로드.
+ *            → (anim_config 설정 시) mesh-processor 자동 병합 → animModelUrl 저장
  *
  * 외부 API 호출은 트랜잭션 밖에서 수행하고,
  * DB 저장/업데이트는 MascotGenerationPersistService를 통해 별도 트랜잭션으로 처리.
@@ -37,6 +43,8 @@ public class MascotGenerationService {
     private final MascotGenerationRepository generationRepository;
     private final SiteRepository siteRepository;
     private final FileStorageService fileStorageService;
+    private final MascotAnimConfigRepository animConfigRepository;
+    private final MeshProcessorClient meshProcessorClient;
 
     /**
      * Step 1: 선업로드된 이미지 URL을 받아 Tripo 3D 생성 task 시작
@@ -120,12 +128,15 @@ public class MascotGenerationService {
             }
 
             if (status.isSuccess() && status.modelUrl() != null) {
-                // 리깅 GLB 다운로드 → 저장 → 파이프라인 완료
+                // 리깅 GLB 다운로드 → 저장
                 byte[] glbBytes = tripoApiService.downloadModel(status.modelUrl());
                 String glbHash = FileValidator.computeFileHash(glbBytes);
                 String modelUrl = fileStorageService.store(siteId, glbHash, glbBytes, "mascot.glb");
                 gen = persistService.applyRigComplete(siteId, generationId, modelUrl);
-                log.info("리깅 GLB 저장 완료(파이프라인 완료): generationId={}", generationId);
+                log.info("리깅 GLB 저장 완료: generationId={}", generationId);
+
+                // anim_config가 설정되어 있으면 mesh-processor로 자동 병합
+                triggerAnimationMerge(siteId, generationId, modelUrl);
             }
 
             return GenerationStatusResponse.from(gen);
@@ -145,6 +156,44 @@ public class MascotGenerationService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MASCOT_GENERATION_NOT_FOUND));
 
         return GenerationStatusResponse.from(gen);
+    }
+
+    /**
+     * rig 완료 후 anim_config가 있으면 mesh-processor에 병합을 요청한다.
+     * 실패해도 파이프라인 완료 처리는 유지 (base GLB 확보됨, animModelUrl만 null로 남음).
+     */
+    private void triggerAnimationMerge(Long siteId, Long generationId, String riggedModelUrl) {
+        List<MascotAnimConfig> animConfigs = animConfigRepository.findBySiteId(siteId);
+        if (animConfigs.isEmpty()) {
+            log.info("anim_config 미설정 — anim 병합 skip: siteId={}", siteId);
+            return;
+        }
+
+        try {
+            // { "Idle": "/app/uploads/1/abc.glb", "Talking": "/app/uploads/1/def.glb", ... }
+            Map<String, String> animGlbs = animConfigs.stream().collect(Collectors.toMap(
+                    MascotAnimConfig::getClipName,
+                    c -> fileStorageService.toLocalPath(c.getGlbUrl()).toString()
+            ));
+
+            String riggedLocalPath = fileStorageService.toLocalPath(riggedModelUrl).toString();
+            String animFilename    = "anim_" + generationId + ".glb";
+            String animModelUrl    = fileStorageService.resolveUrl(siteId, animFilename);
+            String animLocalPath   = fileStorageService.toLocalPath(animModelUrl).toString();
+
+            meshProcessorClient.combine(riggedLocalPath, animGlbs, animLocalPath);
+
+            Map<String, String> animClips = animConfigs.stream().collect(Collectors.toMap(
+                    MascotAnimConfig::getStateKey,
+                    MascotAnimConfig::getClipName
+            ));
+            persistService.applyAnimationComplete(siteId, generationId, animModelUrl, animClips);
+            log.info("anim GLB 자동 병합 완료: generationId={}, animModelUrl={}", generationId, animModelUrl);
+
+        } catch (Exception e) {
+            log.warn("mesh-processor 실패 — animModelUrl 없이 완료: generationId={}, err={}",
+                    generationId, e.getMessage());
+        }
     }
 
     private void validatePlatformAdmin(CustomAdminDetails adminDetails) {

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MeshProcessorClient.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/domain/mascot/service/MeshProcessorClient.java
@@ -1,0 +1,78 @@
+package com.guideon.guideonbackend.domain.mascot.service;
+
+import com.guideon.common.exception.CustomException;
+import com.guideon.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+/**
+ * mesh-processor(Node.js :3001) 클라이언트.
+ * Tripo rig GLB + 상태별 Mixamo 애니메이션 GLB → 통합 anim GLB 병합 요청.
+ * admin-bff와 mesh-processor는 동일 볼륨(./uploads:/app/uploads)을 공유하므로
+ * 파일시스템 경로를 직접 전달한다.
+ */
+@Slf4j
+@Service
+public class MeshProcessorClient {
+
+    private final String baseUrl;
+    private final RestTemplate restTemplate;
+
+    public MeshProcessorClient(
+            @Value("${mesh-processor.url:http://mesh-processor:3001}") String baseUrl,
+            @Value("${mesh-processor.connect-timeout:5000}") int connectTimeout,
+            @Value("${mesh-processor.read-timeout:120000}") int readTimeout) {
+        this.baseUrl = baseUrl;
+
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(connectTimeout);
+        factory.setReadTimeout(readTimeout);
+        this.restTemplate = new RestTemplate(factory);
+
+        log.info("MeshProcessorClient 초기화: url={}", baseUrl);
+    }
+
+    /**
+     * GLB 병합 요청.
+     *
+     * @param baseGlbPath  Tripo 리깅 완료 GLB 로컬 경로 (예: /app/uploads/1/abc.glb)
+     * @param animGlbs     { "Idle": "/app/uploads/1/def.glb", "Talking": "..." }
+     *                     KEY = GLB 내부에 임베드될 Animation 클립명
+     * @param outputPath   출력 GLB 로컬 경로 (예: /app/uploads/1/anim_42.glb)
+     */
+    @SuppressWarnings("unchecked")
+    public void combine(String baseGlbPath, Map<String, String> animGlbs, String outputPath) {
+        Map<String, Object> body = Map.of(
+                "baseGlb",   baseGlbPath,
+                "animGlbs",  animGlbs,
+                "outputGlb", outputPath
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        try {
+            Map<String, Object> response = restTemplate.postForObject(
+                    baseUrl + "/combine",
+                    new HttpEntity<>(body, headers),
+                    Map.class
+            );
+            log.info("mesh-processor 병합 완료: outputGlb={}", outputPath);
+            if (response != null && Boolean.FALSE.equals(response.get("success"))) {
+                throw new CustomException(ErrorCode.UPSTREAM_TIMEOUT,
+                        "mesh-processor 병합 실패: " + response.get("error"));
+            }
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.UPSTREAM_TIMEOUT,
+                    "mesh-processor 호출 실패: " + e.getMessage());
+        }
+    }
+}

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/FileStorageService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/FileStorageService.java
@@ -2,6 +2,8 @@ package com.guideon.guideonbackend.global.storage;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import java.nio.file.Path;
+
 /**
  * 파일 저장 서비스 인터페이스
  * Local / S3 등 구현체를 교체 가능
@@ -19,4 +21,17 @@ public interface FileStorageService {
     byte[] loadBytes(Long siteId, String storageUrl);
 
     void delete(String storageUrl);
+
+    /**
+     * 서빙 URL → 로컬 파일시스템 Path 변환.
+     * mesh-processor가 파일에 직접 접근할 때 사용.
+     * 예: "http://admin-bff:8081/internal/files/1/abc.glb" → /app/uploads/1/abc.glb
+     */
+    Path toLocalPath(String storageUrl);
+
+    /**
+     * siteId + filename → 서빙 URL 조합.
+     * mesh-processor 출력 파일의 URL 생성에 사용.
+     */
+    String resolveUrl(Long siteId, String filename);
 }

--- a/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/LocalFileStorageService.java
+++ b/guideon-admin-bff/src/main/java/com/guideon/guideonbackend/global/storage/LocalFileStorageService.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -120,6 +121,28 @@ public class LocalFileStorageService implements FileStorageService {
         } catch (IOException e) {
             log.warn("파일 삭제 실패 (무시): storageUrl={}, error={}", storageUrl, e.getMessage());
         }
+    }
+
+    @Override
+    public Path toLocalPath(String storageUrl) {
+        // "http://admin-bff:8081/internal/files/1/abc.glb" → uploadDir/1/abc.glb
+        String prefix = "/internal/files/";
+        int idx = Objects.requireNonNull(storageUrl, "storageUrl").indexOf(prefix);
+        if (idx < 0) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR,
+                    "toLocalPath: 올바른 /internal/files/ URL이 아닙니다: " + storageUrl);
+        }
+        String relative = storageUrl.substring(idx + prefix.length()); // "1/abc.glb"
+        Path resolved = uploadDir.resolve(relative).normalize();
+        if (!resolved.startsWith(uploadDir)) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "허용되지 않은 파일 경로입니다.");
+        }
+        return resolved;
+    }
+
+    @Override
+    public String resolveUrl(Long siteId, String filename) {
+        return fileBaseUrl + "/internal/files/" + siteId + "/" + filename;
     }
 
     private String extractExtension(String filename) {

--- a/guideon-admin-bff/src/main/resources/application.yml
+++ b/guideon-admin-bff/src/main/resources/application.yml
@@ -114,6 +114,12 @@ fastapi:
     connect-timeout: 10000    # 연결 타임아웃 (ms)
     read-timeout: 120000      # Cartesia 처리 시간 고려
 
+# Mesh Processor (Node.js GLB 병합 서비스)
+mesh-processor:
+  url: ${MESH_PROCESSOR_URL:http://mesh-processor:3001}
+  connect-timeout: 5000
+  read-timeout: 120000   # GLB 병합 작업 최대 2분
+
 # Tripo AI (3D Model Generation)
 tripo:
   api-key: ${TRIPO_API_KEY}

--- a/guideon-core/src/main/java/com/guideon/core/domain/mascot/entity/MascotAnimConfig.java
+++ b/guideon-core/src/main/java/com/guideon/core/domain/mascot/entity/MascotAnimConfig.java
@@ -1,0 +1,65 @@
+package com.guideon.core.domain.mascot.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * 사이트별 마스코트 애니메이션 설정.
+ * state_key(idle/speaking 등) → clip_name(GLB 내 클립명) + glb_url(원본 GLB 파일 URL)
+ * 1회 설정 후 마스코트 생성(rig 완료)마다 mesh-processor가 자동 병합에 사용.
+ */
+@Entity
+@Table(name = "tb_mascot_anim_config")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MascotAnimConfig {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "site_id", nullable = false)
+    private Long siteId;
+
+    /** 상태 키: idle | speaking | listening | thinking | greeting */
+    @Column(name = "state_key", nullable = false, length = 20)
+    private String stateKey;
+
+    /** GLB 내부 클립명 — combiner.js가 이 이름으로 Animation을 임베드 */
+    @Column(name = "clip_name", nullable = false, length = 50)
+    private String clipName;
+
+    /** 원본 GLB 파일 URL (admin-bff /internal/files/... 경로) */
+    @Column(name = "glb_url", nullable = false, length = 500)
+    private String glbUrl;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @Builder
+    public MascotAnimConfig(Long siteId, String stateKey, String clipName, String glbUrl) {
+        this.siteId = siteId;
+        this.stateKey = stateKey;
+        this.clipName = clipName;
+        this.glbUrl = glbUrl;
+        this.updatedAt = Instant.now();
+    }
+
+    public void update(String clipName, String glbUrl) {
+        this.clipName = clipName;
+        this.glbUrl = glbUrl;
+        this.updatedAt = Instant.now();
+    }
+
+    /** 클립명만 수정 (GLB 파일 변경 없이 매핑만 수정할 때) */
+    public void updateClipName(String clipName) {
+        this.clipName = clipName;
+        this.updatedAt = Instant.now();
+    }
+}

--- a/guideon-core/src/main/java/com/guideon/core/domain/mascot/repository/MascotAnimConfigRepository.java
+++ b/guideon-core/src/main/java/com/guideon/core/domain/mascot/repository/MascotAnimConfigRepository.java
@@ -1,0 +1,16 @@
+package com.guideon.core.domain.mascot.repository;
+
+import com.guideon.core.domain.mascot.entity.MascotAnimConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MascotAnimConfigRepository extends JpaRepository<MascotAnimConfig, Long> {
+
+    List<MascotAnimConfig> findBySiteId(Long siteId);
+
+    Optional<MascotAnimConfig> findBySiteIdAndStateKey(Long siteId, String stateKey);
+
+    boolean existsBySiteId(Long siteId);
+}

--- a/infra/init.sql
+++ b/infra/init.sql
@@ -419,3 +419,16 @@ CREATE INDEX IF NOT EXISTS idx_pairing_status_expires ON tb_pairing_request (sta
 CREATE OR REPLACE TRIGGER trg_pairing_request_updated_at
 BEFORE UPDATE ON tb_pairing_request
 FOR EACH ROW EXECUTE FUNCTION guideon_set_updated_at();
+
+-- tb_mascot_anim_config: 사이트별 state→클립명+GLB URL (1회 설정 후 마스코트 생성마다 재활용)
+CREATE TABLE IF NOT EXISTS tb_mascot_anim_config (
+  id          BIGSERIAL PRIMARY KEY,
+  site_id     BIGINT NOT NULL REFERENCES tb_site(site_id) ON DELETE CASCADE,
+  state_key   VARCHAR(20) NOT NULL,    -- idle | speaking | listening | thinking | greeting
+  clip_name   VARCHAR(50) NOT NULL,    -- GLB 내부 클립명 (combiner.js가 이 이름으로 임베드)
+  glb_url     VARCHAR(500) NOT NULL,   -- http://.../internal/files/... (admin-bff 서빙 URL)
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT uk_anim_config_site_state UNIQUE (site_id, state_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_anim_config_site ON tb_mascot_anim_config (site_id);

--- a/mesh-processor/Dockerfile
+++ b/mesh-processor/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install --production
+COPY src ./src
+EXPOSE 3001
+CMD ["node", "src/index.js"]

--- a/mesh-processor/package.json
+++ b/mesh-processor/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "mesh-processor",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@gltf-transform/core": "^4.0.0",
+    "@gltf-transform/extensions": "^4.0.0",
+    "@gltf-transform/functions": "^4.0.0",
+    "express": "^4.18.0"
+  }
+}

--- a/mesh-processor/src/combiner.js
+++ b/mesh-processor/src/combiner.js
@@ -1,0 +1,89 @@
+import { NodeIO }         from '@gltf-transform/core';
+import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
+
+const io = new NodeIO().registerExtensions(ALL_EXTENSIONS);
+
+/**
+ * Tripo rigged GLB + Mixamo 애니메이션 GLB 5개 → 통합 anim GLB
+ *
+ * 핵심 원리:
+ *   Mixamo "Without Skin" GLB의 본 이름(mixamorig:Hips 등)이
+ *   Tripo spec:mixamo GLB의 본 이름과 동일하므로,
+ *   이름 기준으로 채널 타깃을 remapping하여 베이스 문서에 붙인다.
+ *
+ * @param {string} baseGlbPath  Tripo rig_model 결과 GLB 경로
+ * @param {Object} animGlbs     { "Idle": "/path/idle.glb", "Talking": "/path/talking.glb", ... }
+ *                              KEY = GLB에 임베드될 클립명, VALUE = 파일 경로
+ * @param {string} outputPath   출력 GLB 경로
+ */
+export async function combine(baseGlbPath, animGlbs, outputPath) {
+  console.log(`[combine] base: ${baseGlbPath}`);
+
+  // 1. 베이스 문서 로드 (Tripo 리깅 GLB — 메쉬 + 스켈레톤 포함)
+  const baseDoc  = await io.read(baseGlbPath);
+  const baseRoot = baseDoc.getRoot();
+
+  // 2. 베이스 스켈레톤의 본 이름 → 노드 맵 구성
+  const nodeByName = new Map();
+  for (const node of baseRoot.listNodes()) {
+    nodeByName.set(node.getName(), node);
+  }
+  console.log(`[combine] 베이스 본 ${nodeByName.size}개 인식`);
+
+  // 3. 각 애니메이션 GLB에서 클립 추출 → 베이스에 이식
+  for (const [clipName, animPath] of Object.entries(animGlbs)) {
+    console.log(`[combine] 클립 병합: ${clipName} ← ${animPath}`);
+
+    const animDoc  = await io.read(animPath);
+    const animRoot = animDoc.getRoot();
+
+    for (const srcAnim of animRoot.listAnimations()) {
+      const newAnim = baseDoc.createAnimation(clipName);
+      let channelCount = 0;
+
+      for (const channel of srcAnim.listChannels()) {
+        const srcTarget = channel.getTargetNode();
+        if (!srcTarget) continue;
+
+        // 본 이름으로 베이스 문서의 동일한 본 찾기
+        const baseTarget = nodeByName.get(srcTarget.getName());
+        if (!baseTarget) continue; // 매칭 본 없으면 skip
+
+        const srcSampler = channel.getSampler();
+        const srcInput   = srcSampler.getInput();
+        const srcOutput  = srcSampler.getOutput();
+
+        // Accessor 데이터 복사 (참조가 아닌 deep copy — 문서 간 공유 불가)
+        const newInput = baseDoc.createAccessor()
+          .setType(srcInput.getType())
+          .setComponentType(srcInput.getComponentType())
+          .setArray(srcInput.getArray().slice());
+
+        const newOutput = baseDoc.createAccessor()
+          .setType(srcOutput.getType())
+          .setComponentType(srcOutput.getComponentType())
+          .setArray(srcOutput.getArray().slice());
+
+        const newSampler = baseDoc.createAnimationSampler()
+          .setInput(newInput)
+          .setOutput(newOutput)
+          .setInterpolation(srcSampler.getInterpolation());
+
+        const newChannel = baseDoc.createAnimationChannel()
+          .setSampler(newSampler)
+          .setTargetNode(baseTarget)          // ← 베이스 문서의 본으로 교체
+          .setTargetPath(channel.getTargetPath());
+
+        newAnim.addSampler(newSampler);
+        newAnim.addChannel(newChannel);
+        channelCount++;
+      }
+
+      console.log(`  ${clipName}: ${channelCount}개 채널 이식 완료`);
+    }
+  }
+
+  // 4. 통합 GLB 출력
+  await io.write(outputPath, baseDoc);
+  console.log(`[combine] 완료: ${outputPath}`);
+}

--- a/mesh-processor/src/index.js
+++ b/mesh-processor/src/index.js
@@ -1,0 +1,46 @@
+import express from 'express';
+import { combine } from './combiner.js';
+
+const app  = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(express.json());
+
+/**
+ * POST /combine
+ * {
+ *   "baseGlb":   "/app/uploads/{siteId}/{hash}.glb",  — Tripo rig_model 결과 GLB
+ *   "animGlbs":  {
+ *     "Idle":      "/app/uploads/{siteId}/{hash}.glb",
+ *     "Talking":   "/app/uploads/{siteId}/{hash}.glb",
+ *     "Listening": "/app/uploads/{siteId}/{hash}.glb",
+ *     "Thinking":  "/app/uploads/{siteId}/{hash}.glb",
+ *     "Waving":    "/app/uploads/{siteId}/{hash}.glb"
+ *   },
+ *   "outputGlb": "/app/uploads/{siteId}/anim_{generationId}.glb"
+ * }
+ *
+ * 응답: { "success": true, "outputGlb": "..." }
+ */
+app.post('/combine', async (req, res) => {
+  const { baseGlb, animGlbs, outputGlb } = req.body;
+
+  if (!baseGlb || !animGlbs || !outputGlb) {
+    return res.status(400).json({ error: 'baseGlb, animGlbs, outputGlb 필수' });
+  }
+  if (typeof animGlbs !== 'object' || Object.keys(animGlbs).length === 0) {
+    return res.status(400).json({ error: 'animGlbs는 비어있지 않은 객체여야 합니다' });
+  }
+
+  try {
+    await combine(baseGlb, animGlbs, outputGlb);
+    res.json({ success: true, outputGlb });
+  } catch (e) {
+    console.error('[combine] 실패:', e.message);
+    res.status(500).json({ error: e.message });
+  }
+});
+
+app.get('/health', (_, res) => res.json({ status: 'ok' }));
+
+app.listen(PORT, () => console.log(`mesh-processor :${PORT}`));


### PR DESCRIPTION
## Summary
- #191 
- Mixamo 애니메이션 GLB 수동 병합·업로드 방식에서 **mesh-processor 자동 병합**으로 전환합니다.

## Tasks
 ### 1. DB / 엔티티
  - `tb_mascot_anim_config` 신규 테이블 — 사이트별 state→clip_name+glb_url 저장
  - `MascotAnimConfig` JPA 엔티티 + `MascotAnimConfigRepository`

  ### 2. mesh-processor 서비스 (Node.js)
  - `mesh-processor/` 디렉터리 신규 생성
  - `POST /combine` — Tripo 리깅 GLB + 상태별 애니메이션 GLB → 통합 anim GLB
  - gltf-transform 기반, 본 이름(mixamorig:\*) 매핑으로 채널 remapping
  - `docker-compose.yml`에 서비스 추가 (`./uploads:/app/uploads` 볼륨 공유)

  ### 3. Admin API 신규
  - `POST /api/v1/admin/sites/{siteId}/mascot/animations` — state별 GLB 업로드 (idle/speaking/listening/thinking/greeting)
  - `GET /api/v1/admin/sites/{siteId}/mascot/anim-config` — 현재 매핑 조회
  - `PUT /api/v1/admin/sites/{siteId}/mascot/anim-config` — 클립명만 수정

  ### 4. 자동 파이프라인 연결
  - `MascotGenerationService`: rig 완료 후 `triggerAnimationMerge()` 호출
  - `MeshProcessorClient` (RestTemplate, 타임아웃 2분)
  - `FileStorageService.toLocalPath()` / `resolveUrl()` 추가
  - mesh-processor 실패 시 경고 로그만 남기고 base GLB 유지 (폴백)

## To Reviewer
- 

## Screenshot
<img src="" width="50%" />