### PR TITLE
chore: DB 이미지 경량화 및 배포 후 docker prune 필터 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,6 @@ jobs:
             docker compose pull
             docker compose up -d
             docker exec guideon-nginx nginx -s reload
-            docker image prune -af --filter "until=168h"
+            docker image prune -af
             echo "=== Deploy complete ==="
             docker compose ps

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -1,18 +1,8 @@
 FROM postgis/postgis:16-3.4
 
-RUN apt-get update && apt-get install -y \
-    git \
-    make \
-    build-essential \
-    postgresql-server-dev-16 \
-    clang-13 \
-    llvm-13 \
+# pgvector: 빌드 도구 없이 PGDG apt 패키지로 설치 (이미지 크기 ~2GB 절감)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-16-pgvector \
     && rm -rf /var/lib/apt/lists/*
-
-RUN cd /tmp && \
-    git clone --branch v0.7.0 https://github.com/pgvector/pgvector.git && \
-    cd pgvector && \
-    make && \
-    make install
 
 COPY init.sql /docker-entrypoint-initdb.d/20_init.sql


### PR DESCRIPTION
  ## Summary
  - `infra/Dockerfile`: pgvector를 소스 빌드(build-essential/clang/llvm/git)에서 PGDG apt 패키지(`postgresql-16-pgvector`)로 교체 → db 이미지 **3GB → ~900MB** 예상
  - `deploy.yml`: `docker image prune`에서 `--filter until=168h` 제거 → 배포 주기(~6일)가 필터(7일)보다 짧아 dangling 이미지가 누적되던 버그 수정

  ## 배경
  서버 디스크가 97%까지 차 SSH 속도 저하/불안정 발생. 진단 결과 dangling 이미지 22개(~6GB)가 `/var/lib/containerd`에 누적된 것이 원인. prune 필터 때문에 6일 전 이미지(144h)가 168h 기준에 안 걸려 계속 남아있었음.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker 이미지 정리 프로세스 개선으로 미사용 이미지 제거 범위 확대
  * 데이터베이스 확장 모듈 설치 방식을 소스 빌드에서 패키지 기반으로 변경하여 배포 효율성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->